### PR TITLE
docs: update Go versions, add hystrix-go deprecation notices

### DIFF
--- a/Cookiecutter.md
+++ b/Cookiecutter.md
@@ -56,9 +56,9 @@ project_short_description [A Golang project.]: A Golang project
 docker_image [alpine:latest]:
 docker_build_image [golang]:
 Select docker_build_image_version:
-1 - 1.19
-2 - 1.20
-Choose from 1, 2 [1]: 2
+1 - 1.25
+2 - 1.24
+Choose from 1, 2 [1]: 1
 {% endhighlight %}
 
 ## Checkout your new project

--- a/Index.md
+++ b/Index.md
@@ -35,7 +35,7 @@ ColdBrew integrates with all the popular libraries. We strongly believe in the [
 - [opentelemetry] - Tracing
 - [jaeger] - Tracing
 - [opentracing] - Tracing
-- [hystrix-go] - Circuit Breaker
+- [hystrix-go] - Circuit Breaker (deprecated, consider [failsafe-go])
 - [new relic] - Monitoring
 - [sentry] - Error Reporting
 - [go-grpc-middleware] - Middlewares: interceptors, helpers and utilities.
@@ -58,6 +58,7 @@ ColdBrew integrates with all the popular libraries. We strongly believe in the [
 [new relic]: https://newrelic.com/
 [sentry]: https://sentry.io/
 [go-grpc-middleware]: https://pkg.go.dev/github.com/grpc-ecosystem/go-grpc-middleware
+[failsafe-go]: https://github.com/failsafe-go/failsafe-go
 [grpc_retry]: https://pkg.go.dev/github.com/grpc-ecosystem/go-grpc-middleware/retry
 [opentelemetry]: https://opentelemetry.io/
 [DRY]: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself

--- a/Packages.md
+++ b/Packages.md
@@ -49,8 +49,8 @@ Tracing is a library that provides distributed tracing to Go applications. It of
 
 Documentation can be found at [tracing-docs]
 
-## [Hystrix Prometheus]
-hystrixprometheus provides a Prometheus metrics collector for Hystrix (https://github.com/afex/hystrix-go). This is a workaround for hystrix-go not supporting the prometheus registry
+## [Hystrix Prometheus] (Deprecated)
+hystrixprometheus provides a Prometheus metrics collector for Hystrix (https://github.com/afex/hystrix-go). This package is deprecated as hystrix-go is unmaintained. Consider migrating to [failsafe-go](https://github.com/failsafe-go/failsafe-go).
 
 Documentation can be found at [hystrixprometheus-docs]
 

--- a/howto/Metrics.md
+++ b/howto/Metrics.md
@@ -52,6 +52,9 @@ To learn more about the Prometheus and the data types it supports, see [here](ht
 
 ## How to use Hystrix Metrics in Prometheus
 
+{: .warning }
+Hystrix-Go is unmaintained (last updated 2018). Consider migrating to [failsafe-go](https://github.com/failsafe-go/failsafe-go) for circuit breaker functionality.
+
 [Hystrix Prometheus] is a library that provides a Prometheus metrics collector for [Hystrix-go]. To use it, you can register the collector with the default Prometheus registry:
 
 ```go

--- a/integrations.md
+++ b/integrations.md
@@ -217,6 +217,9 @@ func main() {
 
 ## Hystrix-Go
 
+{: .warning }
+Hystrix-Go (`afex/hystrix-go`) is unmaintained (last updated 2018). Consider migrating to [failsafe-go] for circuit breaker functionality.
+
 [Hystrix-Go] is a Go implementation of the circuit breaker pattern. ColdBrew provides Prometheus metrics integration for Hystrix.
 
 ### Initialising
@@ -289,5 +292,6 @@ To see all the Coldbrew packages, check out the [Coldbrew packages] page.
 [SetupOpenTelemetry]: https://pkg.go.dev/github.com/go-coldbrew/core#SetupOpenTelemetry
 [SetupLogger]: https://pkg.go.dev/github.com/go-coldbrew/core#SetupLogger
 [SetupHystrixPrometheus]: https://pkg.go.dev/github.com/go-coldbrew/core#SetupHystrixPrometheus
+[failsafe-go]: https://github.com/failsafe-go/failsafe-go
 [SetupEnvironment]: https://pkg.go.dev/github.com/go-coldbrew/core#SetupEnvironment
 [SetupReleaseName]: https://pkg.go.dev/github.com/go-coldbrew/core#SetupReleaseName


### PR DESCRIPTION
## Summary
- Update Cookiecutter example to show Go 1.25/1.24 instead of 1.19/1.20
- Add deprecation warnings for hystrix-go on Index, Integrations, Metrics, and Packages pages
- Recommend failsafe-go as replacement

## Test plan
- [x] Verify pages render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Go image version recommendations in setup documentation (upgraded to versions 1.25 and 1.24 instead of 1.19 and 1.20)
  * Marked Hystrix-Go circuit breaker library as deprecated throughout documentation
  * Added migration guidance directing users to failsafe-go for circuit breaker functionality
  * Added deprecation warnings noting Hystrix-Go library is unmaintained since 2018

<!-- end of auto-generated comment: release notes by coderabbit.ai -->