### PR TITLE
docs: update Prometheus interceptor package name after Phase 4 migration

### DIFF
--- a/Index.md
+++ b/Index.md
@@ -99,11 +99,11 @@ Run `buf generate` — it creates typed Go interfaces from your proto definition
                     │  │ Gateway  │──► │                     │  │
                     │  │ (grpc-  │    │  ► Response Time    │  │
    gRPC Request ──► │  │ gateway)│    │  ► Trace ID         │  │
-                    │  └─────────┘    │  ► Context Tags     │  │
-                    │       │         │  ► OpenTelemetry     │  │
-                    │       ▼         │  ► Prometheus        │  │
-                    │  ┌─────────┐    │  ► Error Notify      │  │
-                    │  │  gRPC   │──► │  ► Panic Recovery    │  │──► Your Handler
+                    │  └─────────┘    │  ► OpenTelemetry     │  │
+                    │       │         │  ► Prometheus        │  │
+                    │       ▼         │  ► Error Notify      │  │
+                    │  ┌─────────┐    │  ► Panic Recovery    │  │
+                    │  │  gRPC   │──► │                     │  │──► Your Handler
                     │  │ Server  │    │                     │  │
                     │  └─────────┘    └────────────────────┘  │
                     │                                         │
@@ -156,7 +156,7 @@ ColdBrew integrates with the tools you already use:
 [opentelemetry]: https://opentelemetry.io/
 [new relic]: https://newrelic.com/
 [sentry]: https://sentry.io/
-[go-grpc-middleware]: https://pkg.go.dev/github.com/grpc-ecosystem/go-grpc-middleware
+[go-grpc-middleware]: https://pkg.go.dev/github.com/grpc-ecosystem/go-grpc-middleware/v2
 [vtprotobuf]: https://github.com/planetscale/vtprotobuf
 [pprof]: https://pkg.go.dev/net/http/pprof
 [grpcurl]: https://github.com/fullstorydev/grpcurl

--- a/architecture.md
+++ b/architecture.md
@@ -154,12 +154,11 @@ When a request arrives at a ColdBrew service, it flows through several layers:
   │  │                                           │   │
   │  │  1. Response Time Logging                 │   │
   │  │  2. Trace ID Injection                    │   │
-  │  │  3. Context Tags (grpc_ctxtags)           │   │
-  │  │  4. OpenTracing / OpenTelemetry           │   │
-  │  │  5. Prometheus Metrics                    │   │
-  │  │  6. Error Notification (Sentry/Rollbar)   │   │
-  │  │  7. New Relic Transaction                 │   │
-  │  │  8. Panic Recovery                        │   │
+  │  │  3. OpenTracing / OpenTelemetry           │   │
+  │  │  4. Prometheus Metrics                    │   │
+  │  │  5. Error Notification (Sentry/Rollbar)   │   │
+  │  │  6. New Relic Transaction                 │   │
+  │  │  7. Panic Recovery                        │   │
   │  │                                           │   │
   │  └────────────────────┬─────────────────────┘   │
   │                       │                          │
@@ -201,12 +200,11 @@ Interceptors are gRPC middleware that run on every request. ColdBrew chains them
 |-------|------------|---------|--------------|
 | 1 | Response Time Logging | `interceptors` | Logs method name, duration, and status code |
 | 2 | Trace ID | `interceptors` | Generates a trace ID (or reads it from the `x-trace-id` HTTP header or a `trace_id` proto field) and propagates it to structured logs and Sentry/Rollbar error reports |
-| 3 | Context Tags | `grpc_ctxtags` | Extracts gRPC metadata into context tags for logging |
-| 4 | OpenTracing | `grpc_opentracing` | Creates a tracing span for the request |
-| 5 | Prometheus | `grpc_prometheus` | Records request count, latency histogram, and status codes |
-| 6 | Error Notification | `interceptors` | Sends errors to Sentry/Rollbar/Airbrake asynchronously |
-| 7 | New Relic | `interceptors` | Creates a New Relic transaction for APM |
-| 8 | Panic Recovery | `interceptors` | Catches panics and converts them to gRPC errors |
+| 3 | OpenTracing | `grpc_opentracing` | Creates a tracing span for the request |
+| 4 | Prometheus | `interceptors` | Records request count, latency histogram, and status codes |
+| 5 | Error Notification | `interceptors` | Sends errors to Sentry/Rollbar/Airbrake asynchronously |
+| 6 | New Relic | `interceptors` | Creates a New Relic transaction for APM |
+| 7 | Panic Recovery | `interceptors` | Catches panics and converts them to gRPC errors |
 
 {: .note }
 Health checks, ready checks, and gRPC reflection are **excluded by default** via `FilterMethods`. This prevents observability noise from Kubernetes probes. See the [FAQ](/faq) for how to customize this.

--- a/howto/Debugging.md
+++ b/howto/Debugging.md
@@ -115,12 +115,11 @@ LOG_LEVEL=debug make run
 The server interceptor chain runs in this order:
 1. Response time logging
 2. Trace ID injection
-3. Context tags
-4. OpenTracing/OpenTelemetry
-5. Prometheus metrics
-6. Error notification
-7. NewRelic
-8. Panic recovery
+3. OpenTracing/OpenTelemetry
+4. Prometheus metrics
+5. Error notification
+6. NewRelic
+7. Panic recovery
 
 If a request is failing or behaving unexpectedly, check whether an interceptor is modifying the context or returning early. The response time logging interceptor logs every request with method name and duration — check these logs first.
 

--- a/integrations.md
+++ b/integrations.md
@@ -305,7 +305,7 @@ To see all the ColdBrew packages, check out the [ColdBrew packages] page.
 [Opentelemetry]: https://opentelemetry.io/
 [Jaeger]: https://www.jaegertracing.io/
 [Hystrix-Go]: https://pkg.go.dev/github.com/afex/hystrix-go/hystrix
-[Go-grpc-middleware]: https://github.com/grpc-ecosystem/go-grpc-middleware
+[Go-grpc-middleware]: https://github.com/grpc-ecosystem/go-grpc-middleware/v2
 [Core]: https://github.com/go-coldbrew/core/tree/main#readme
 [ColdBrew packages]: /packages
 [Config]: https://pkg.go.dev/github.com/go-coldbrew/core/config#Config


### PR DESCRIPTION
## Summary
- Update interceptor chain table: Prometheus package `grpc_prometheus` → `interceptors` (metrics now managed internally)

## Test plan
- [ ] `npx playwright test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed the “Context Tags” stage from the documented interceptor chain, renumbered subsequent steps, and updated diagrams to reflect the simplified request-processing flow.
  * Updated external library reference to use the v2 module path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->