### PR TITLE
docs: update tracing docs for Jaeger client removal

### DIFF
--- a/Index.md
+++ b/Index.md
@@ -27,7 +27,7 @@ A Kubernetes-native Go microservice framework for building production-grade gRPC
 |---------|-------------|
 | **gRPC + REST Gateway** | Define your API once in protobuf — get gRPC, REST, and [Swagger docs](/architecture#self-documenting-apis) automatically via [grpc-gateway] |
 | **Structured Logging** | Pluggable backends — [slog] (default), zap, go-kit, logrus — with per-request context fields and trace ID propagation |
-| **Distributed Tracing** | [OpenTelemetry], [Jaeger], and [New Relic] support with automatic span creation in interceptors |
+| **Distributed Tracing** | [OpenTelemetry] and [New Relic] support with automatic span creation in interceptors — traces can be sent to any OTLP-compatible backend including [Jaeger] |
 | **Prometheus Metrics** | Built-in request latency, error rate, and circuit breaker metrics at `/metrics` |
 | **Error Tracking** | Stack traces, gRPC status codes, and async notification to [Sentry], Rollbar, or Airbrake |
 | **Resilience** | Client-side circuit breaking and retries via interceptors |

--- a/Packages.md
+++ b/Packages.md
@@ -46,7 +46,7 @@ Documentation can be found at [notifier-docs]
 
 ## [Tracing]
 
-Tracing is a library that provides distributed tracing to Go applications. It offers features such as collecting performance data of an application, identifying where requests are spending most of their time, and segmenting requests. It supports exporting traces via OpenTelemetry to any OTLP-compatible backend (Jaeger, Grafana Tempo, Honeycomb, etc.) and NewRelic.
+Tracing is a library that provides distributed tracing to Go applications. It offers features such as collecting performance data of an application, identifying where requests are spending most of their time, and segmenting requests. It supports exporting traces via OpenTelemetry to any OTLP-compatible backend (Jaeger, Grafana Tempo, Honeycomb, etc.) and New Relic.
 
 Documentation can be found at [tracing-docs]
 

--- a/Packages.md
+++ b/Packages.md
@@ -46,7 +46,7 @@ Documentation can be found at [notifier-docs]
 
 ## [Tracing]
 
-Tracing is a library that provides distributed tracing to Go applications. It offers features such as collecting performance data of an application, identifying where requests are spending most of their time, and segmenting requests. It supports exporting traces to 3rd-party services such as Jaeger, Zipkin, Opentelemetry, and NewRelic.
+Tracing is a library that provides distributed tracing to Go applications. It offers features such as collecting performance data of an application, identifying where requests are spending most of their time, and segmenting requests. It supports exporting traces via OpenTelemetry to any OTLP-compatible backend (Jaeger, Grafana Tempo, Honeycomb, etc.) and NewRelic.
 
 Documentation can be found at [tracing-docs]
 

--- a/config-reference.md
+++ b/config-reference.md
@@ -152,7 +152,7 @@ export NEW_RELIC_APPNAME=myservice
 export SENTRY_DSN=https://your-dsn@sentry.io/123
 ```
 
-## Example: Local Development with Jaeger
+## Example: Local Development with Jaeger (via OTLP)
 
 ```bash
 export APP_NAME=myservice

--- a/howto/Tracing.md
+++ b/howto/Tracing.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Tracing"
 parent: "How To"
-description: "Set up distributed tracing in ColdBrew with OpenTelemetry, Jaeger, and New Relic for gRPC services"
+description: "Set up distributed tracing in ColdBrew with OpenTelemetry and New Relic for gRPC services"
 ---
 ## Table of contents
 {: .no_toc .text-delta }
@@ -12,7 +12,7 @@ description: "Set up distributed tracing in ColdBrew with OpenTelemetry, Jaeger,
 
 ## Overview
 
-ColdBrew provides a way to add tracing to your functions using the [go-coldbrew/tracing] package. The package implements multiple tracing backends (e.g. [New Relic] / [Opentelemetry] / [Jaeger]) which enables you to switch between them without changing your code.
+ColdBrew provides a way to add tracing to your functions using the [go-coldbrew/tracing] package. The package implements tracing via [Opentelemetry] (with support for any OTLP-compatible backend like Jaeger or Grafana Tempo) and [New Relic], enabling you to switch between them without changing your code.
 
 {: .note .note-info }
 Its possible for you to have multiple backends enabled at the same time, for example you can have both [New Relic] and [Opentelemetry] enabled at the same time in the same span and they will both receive the same trace.
@@ -34,7 +34,7 @@ import (
 func myFunction1(ctx context.Context) {
     span, ctx := tracing.NewInternalSpan(ctx, "myFunction1") // start a new span for this function
     defer span.End() // end the span when the function returns
-    span.SetTag("myTag", "myValue") // add a tag to the span to help identify it in the trace view of your tracing system (e.g. Jaeger)
+    span.SetTag("myTag", "myValue") // add a tag to the span to help identify it in your tracing system
     // do something
     myFunction2(ctx)
     // do something

--- a/howto/Tracing.md
+++ b/howto/Tracing.md
@@ -12,10 +12,10 @@ description: "Set up distributed tracing in ColdBrew with OpenTelemetry and New 
 
 ## Overview
 
-ColdBrew provides a way to add tracing to your functions using the [go-coldbrew/tracing] package. The package implements tracing via [Opentelemetry] (with support for any OTLP-compatible backend like Jaeger or Grafana Tempo) and [New Relic], enabling you to switch between them without changing your code.
+ColdBrew provides a way to add tracing to your functions using the [go-coldbrew/tracing] package. The package implements tracing via [OpenTelemetry] (with support for any OTLP-compatible backend like Jaeger or Grafana Tempo) and [New Relic], enabling you to switch between them without changing your code.
 
 {: .note .note-info }
-Its possible for you to have multiple backends enabled at the same time, for example you can have both [New Relic] and [Opentelemetry] enabled at the same time in the same span and they will both receive the same trace.
+Its possible for you to have multiple backends enabled at the same time, for example you can have both [New Relic] and [OpenTelemetry] enabled at the same time in the same span and they will both receive the same trace.
 
 ## Adding Tracing to your functions
 
@@ -23,7 +23,7 @@ ColdBrew provides a way to add tracing to your functions using the [go-coldbrew/
 
 Make sure you use the context returned from the `NewInternalSpan/NewExternalSpan/NewDatabaseSpan` functions. This is because the span is added to the context. If you don't use the context returned from the function, new spans will not be add at the correct place in the trace.
 
-You can also add tags to the span using the `SetTag/SetQuery/SetError` function. These tags will be added to the span and will be visible in the trace view of your tracing system (e.g. New Relic / Opentelemetry).
+You can also add tags to the span using the `SetTag/SetQuery/SetError` function. These tags will be added to the span and will be visible in the trace view of your tracing system (e.g. New Relic / OpenTelemetry).
 
 ```go
 import (
@@ -64,7 +64,7 @@ func main() {
 Adding `defer span.End()` will make sure that the span will end when the function returns. If you don't end the span, it may never be sent to the tracing system and/or have the wrong duration.
 
 ## Adding Tracing to your gRPC services
-When you create a new service with [ColdBrew cookiecutter] it will automatically add tracing (New Relic / Opentelemetry) to your gRPC services. This is done by adding the [interceptors] to your gRPC server.
+When you create a new service with [ColdBrew cookiecutter] it will automatically add tracing (New Relic / OpenTelemetry) to your gRPC services. This is done by adding the [interceptors] to your gRPC server.
 
 {: .note .note-info }
 To disable coldbrew provided interceptors you can call the function [UseColdBrewServcerInterceptors].
@@ -209,7 +209,7 @@ export TRACE_HEADER_NAME=x-request-id  # Use a different header
 [Adding interceptors to your gRPC server]: /howto/interceptors#adding-interceptors-to-your-grpc-server
 [Adding interceptors to your gRPC client]: /howto/interceptors#adding-interceptors-to-your-grpc-client
 [New Relic]: https://newrelic.com/
-[Opentelemetry]: https://opentelemetry.io/
+[OpenTelemetry]: https://opentelemetry.io/
 [Jaeger]: https://www.jaegertracing.io/
 [NewDatastoreSpan]: https://pkg.go.dev/github.com/go-coldbrew/tracing#NewDatastoreSpan
 [NewExternalSpan]: https://pkg.go.dev/github.com/go-coldbrew/tracing#NewExternalSpan

--- a/integrations.md
+++ b/integrations.md
@@ -188,9 +188,9 @@ func main() {
 }
 ```
 
-## Jaeger
+## Jaeger / OTLP-compatible backends
 
-[Jaeger] is an open-source distributed tracing system. ColdBrew supports Jaeger through the generic OpenTelemetry interface.
+[Jaeger] is an open-source distributed tracing system. ColdBrew supports Jaeger (and any OTLP-compatible backend like Grafana Tempo, Honeycomb, etc.) through the OpenTelemetry OTLP exporter.
 
 ### Configuring
 


### PR DESCRIPTION
## Summary

Update docs to reflect that the Jaeger client library has been removed from ColdBrew core. Tracing is now exclusively via OpenTelemetry OTLP.

- Index.md: clarify OTEL as primary, Jaeger as an OTLP-compatible backend
- Packages.md: update tracing description
- howto/Tracing.md: remove Jaeger as a direct backend
- integrations.md: rename section to "OTLP-compatible backends"
- config-reference.md: clarify Jaeger example uses OTLP

Part of go-coldbrew/core#50.