### PR TITLE
docs: add distributed trace propagation section to tracing guide

### DIFF
--- a/howto/Tracing.md
+++ b/howto/Tracing.md
@@ -207,45 +207,50 @@ ColdBrew handles these flows without any code:
 
 | Flow | Propagation | How |
 |------|------------|-----|
-| **Incoming gRPC** | Extracted from gRPC metadata | `otelgrpc` stats handler |
-| **Incoming HTTP** | Extracted from `traceparent` header | `tracingWrapper` middleware |
+| **Incoming gRPC** | Extracted from gRPC metadata | OTEL gRPC stats handler |
+| **Incoming HTTP** | Extracted from `traceparent` header | HTTP gateway tracing middleware |
 | **HTTP → gRPC gateway** | Parent span linked to child | Context propagation via W3C propagator |
-| **gRPC server → client** | Injected into outgoing metadata | `otelgrpc` stats handler |
+| **gRPC server → client** | Injected into outgoing metadata | OTEL gRPC stats handler |
 
 ### Outgoing HTTP calls
 
-When calling external HTTP services, use `NewHTTPExternalSpan` to create a span and inject trace headers:
-
-```go
-span, ctx := tracing.NewHTTPExternalSpan(ctx, "other-service", "/api/data", nil)
-defer span.End()
-
-req, _ := http.NewRequestWithContext(ctx, "GET", "https://other-service/api/data", nil)
-// Inject trace headers into the outgoing request
-otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
-
-resp, err := http.DefaultClient.Do(req)
-```
-
-Or pass the headers directly to let `NewHTTPExternalSpan` inject for you:
+When calling external HTTP services, use `NewHTTPExternalSpan` to create a span and inject trace headers. Pass an `http.Header` to have headers injected automatically:
 
 ```go
 hdr := make(http.Header)
-span, ctx := tracing.NewHTTPExternalSpan(ctx, "other-service", "/api/data", hdr)
+span, ctx := tracing.NewHTTPExternalSpan(ctx, "payment-service", "https://payment-service/api/charge", hdr)
 defer span.End()
 
-req, _ := http.NewRequestWithContext(ctx, "GET", "https://other-service/api/data", nil)
+req, err := http.NewRequestWithContext(ctx, "POST", "https://payment-service/api/charge", body)
+if err != nil {
+    return err
+}
 req.Header = hdr
+
 resp, err := http.DefaultClient.Do(req)
+if err != nil {
+    span.SetError(err)
+    return err
+}
+defer resp.Body.Close()
 ```
 
 {: .important }
-If you make HTTP calls without `NewHTTPExternalSpan`, trace context is **not** propagated automatically. You must inject it manually using `otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))`.
+If you make HTTP calls without `NewHTTPExternalSpan`, trace context is **not** propagated automatically. You must inject it manually:
+
+```go
+req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+if err != nil {
+    return err
+}
+otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
+resp, err := client.Do(req)
+```
 
 ### Verifying propagation
 
 To confirm trace context is flowing correctly, check your tracing backend for:
-- A single trace ID connecting HTTP → gRPC → downstream spans
+- A single OpenTelemetry trace (same W3C trace ID) connecting HTTP → gRPC → downstream spans
 - Parent-child relationships between service boundaries
 - The `traceparent` header in outgoing requests
 

--- a/howto/Tracing.md
+++ b/howto/Tracing.md
@@ -197,6 +197,58 @@ This means a single trace ID connects your logs and error reports — you can se
 export TRACE_HEADER_NAME=x-request-id  # Use a different header
 ```
 
+## Distributed Trace Propagation (W3C)
+
+In addition to ColdBrew's application-level trace ID, OpenTelemetry propagates **W3C trace context** (`traceparent`/`tracestate` headers) for distributed tracing across services. This is what links spans together in your tracing backend (Jaeger, Tempo, etc.).
+
+### What's automatic
+
+ColdBrew handles these flows without any code:
+
+| Flow | Propagation | How |
+|------|------------|-----|
+| **Incoming gRPC** | Extracted from gRPC metadata | `otelgrpc` stats handler |
+| **Incoming HTTP** | Extracted from `traceparent` header | `tracingWrapper` middleware |
+| **HTTP → gRPC gateway** | Parent span linked to child | Context propagation via W3C propagator |
+| **gRPC server → client** | Injected into outgoing metadata | `otelgrpc` stats handler |
+
+### Outgoing HTTP calls
+
+When calling external HTTP services, use `NewHTTPExternalSpan` to create a span and inject trace headers:
+
+```go
+span, ctx := tracing.NewHTTPExternalSpan(ctx, "other-service", "/api/data", nil)
+defer span.End()
+
+req, _ := http.NewRequestWithContext(ctx, "GET", "https://other-service/api/data", nil)
+// Inject trace headers into the outgoing request
+otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
+
+resp, err := http.DefaultClient.Do(req)
+```
+
+Or pass the headers directly to let `NewHTTPExternalSpan` inject for you:
+
+```go
+hdr := make(http.Header)
+span, ctx := tracing.NewHTTPExternalSpan(ctx, "other-service", "/api/data", hdr)
+defer span.End()
+
+req, _ := http.NewRequestWithContext(ctx, "GET", "https://other-service/api/data", nil)
+req.Header = hdr
+resp, err := http.DefaultClient.Do(req)
+```
+
+{: .important }
+If you make HTTP calls without `NewHTTPExternalSpan`, trace context is **not** propagated automatically. You must inject it manually using `otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))`.
+
+### Verifying propagation
+
+To confirm trace context is flowing correctly, check your tracing backend for:
+- A single trace ID connecting HTTP → gRPC → downstream spans
+- Parent-child relationships between service boundaries
+- The `traceparent` header in outgoing requests
+
 ---
 
 [TraceId interceptor]: https://pkg.go.dev/github.com/go-coldbrew/interceptors#TraceIdInterceptor


### PR DESCRIPTION
## Summary

Add "Distributed Trace Propagation (W3C)" section to the tracing howto guide. This was meant to be part of #45 but was pushed after the PR was already merged.

### Content
- Table of automatic propagation flows (incoming gRPC/HTTP, gateway, outgoing gRPC)
- Outgoing HTTP call examples with `NewHTTPExternalSpan`
- Manual injection for plain `http.Client` usage
- Verification tips for tracing backends

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide on W3C distributed trace propagation and how it differs from app-level trace IDs.
  * Documented automatic trace propagation paths across HTTP and gRPC and how outgoing HTTP spans are created.
  * Added a warning and manual-injection example for requests made without the helper.
  * Included a verification checklist to confirm trace linkage in backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->