### PR TITLE
docs: update filter examples to use SetFilterMethods API

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -42,7 +42,7 @@ This is intentional and consistent across the entire codebase. The interceptor c
 func init() {
     // Safe: called during initialization, before server starts
     interceptors.AddUnaryServerInterceptor(context.Background(), myInterceptor)
-    interceptors.SetFilterFunc(myFilter)
+    interceptors.SetFilterFunc(context.Background(), myFilter)
 }
 ```
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -48,21 +48,9 @@ func init() {
 
 ## Why are health checks excluded from tracing and logging?
 
-By default, ColdBrew's `FilterMethods` excludes these methods from interceptor processing:
+Health checks run every few seconds (Kubernetes liveness/readiness probes). Logging and tracing each one would flood your observability systems with noise. By default, ColdBrew filters out `healthcheck`, `readycheck`, and `serverreflectioninfo` methods.
 
-- `/grpc.health.v1.Health/Check`
-- `/grpc.health.v1.Health/Watch`
-- `/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo`
-
-Health checks run every few seconds (Kubernetes liveness/readiness probes). Logging and tracing each one would flood your observability systems with noise. If you need to include them, override the filter:
-
-```go
-func init() {
-    interceptors.SetFilterFunc(context.Background(), func(ctx context.Context, fullMethodName string) bool {
-        return true // don't filter anything
-    })
-}
-```
+See [Filtering response time logs](/howto/interceptors#filtering-response-time-logs) for how to customize which methods are filtered.
 
 ## How does trace ID propagation work?
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -58,8 +58,8 @@ Health checks run every few seconds (Kubernetes liveness/readiness probes). Logg
 
 ```go
 func init() {
-    interceptors.SetFilterFunc(func(fullMethodName string) bool {
-        return false // don't filter anything
+    interceptors.SetFilterFunc(context.Background(), func(ctx context.Context, fullMethodName string) bool {
+        return true // don't filter anything
     })
 }
 ```

--- a/Index.md
+++ b/Index.md
@@ -36,7 +36,7 @@ A Kubernetes-native Go microservice framework for building production-grade gRPC
 | **Swagger / OpenAPI** | Interactive API docs auto-served at `/swagger/` from your protobuf definitions |
 | **Profiling** | Go [pprof] endpoints at `/debug/pprof/` for CPU, memory, goroutine, and trace profiling |
 | **gRPC Reflection** | Server reflection enabled by default — works with [grpcurl], [grpcui], and Postman |
-| **HTTP Compression** | Automatic gzip compression for all HTTP gateway responses |
+| **HTTP Compression** | Automatic gzip and [zstd] compression for all HTTP gateway responses (content-negotiated via `Accept-Encoding`) |
 | **Container-aware Runtime** | Auto-tunes GOMAXPROCS to match container CPU limits via [automaxprocs] |
 | **CI/CD Pipelines** | Ready-to-use [GitHub Actions] and [GitLab CI] workflows for build, test, lint, coverage, and benchmarks |
 
@@ -167,3 +167,4 @@ ColdBrew integrates with the tools you already use:
 [GitHub Actions]: https://github.com/features/actions
 [GitLab CI]: https://docs.gitlab.com/ci/
 [slog]: https://pkg.go.dev/log/slog
+[zstd]: https://datatracker.ietf.org/doc/html/rfc8878

--- a/howto/interceptors.md
+++ b/howto/interceptors.md
@@ -31,24 +31,40 @@ It's possible to filter out response time log messages by using a [FilterFunc]. 
 You can replace the default filter list using [SetFilterMethods]. This **overwrites** the entire list, so include the defaults if you want to keep them. Matching is **case-insensitive** (entries and method names are lowercased internally) and works for both gRPC methods and HTTP paths:
 
 ```go
-interceptors.SetFilterMethods(context.Background(), []string{
-    "healthcheck", "readycheck", "serverreflectioninfo", // defaults
-    "/echo",           // exclude HTTP path /echo
-    "mysvc/echo",      // exclude gRPC method /com.github.ankurs.MySvc/Echo
-})
+import (
+    "context"
+    "github.com/go-coldbrew/interceptors"
+)
+
+func init() {
+    interceptors.SetFilterMethods(context.Background(), []string{
+        "healthcheck", "readycheck", "serverreflectioninfo", // defaults
+        "/echo",           // exclude HTTP path /echo
+        "mysvc/echo",      // exclude gRPC method /com.github.ankurs.MySvc/Echo
+    })
+}
 ```
 
 For more advanced filtering, provide your own [FilterFunc] via [SetFilterFunc]. The function receives the **original-case** method name and the request context, which lets you distinguish gRPC from HTTP requests. Return `true` to include a method in tracing/logging, or `false` to exclude it:
 
 ```go
-interceptors.SetFilterFunc(context.Background(), func(ctx context.Context, method string) bool {
-    if _, ok := grpc.Method(ctx); ok {
-        // gRPC: only trace MyService methods
-        return strings.Contains(method, "MySvc")
-    }
-    // HTTP: trace everything except health and ready checks
-    return method != "/healthcheck" && method != "/readycheck"
-})
+import (
+    "context"
+    "strings"
+    "github.com/go-coldbrew/interceptors"
+    "google.golang.org/grpc"
+)
+
+func init() {
+    interceptors.SetFilterFunc(context.Background(), func(ctx context.Context, method string) bool {
+        if _, ok := grpc.Method(ctx); ok {
+            // gRPC: only trace MyService methods
+            return strings.Contains(method, "MySvc")
+        }
+        // HTTP: trace everything except health and ready checks
+        return method != "/healthcheck" && method != "/readycheck"
+    })
+}
 ```
 
 ## Adding interceptors to your gRPC server

--- a/howto/interceptors.md
+++ b/howto/interceptors.md
@@ -28,17 +28,17 @@ ColdBrew uses interceptors to implement response time logging in [ResponseTimeLo
 
 It's possible to filter out response time log messages by using a [FilterFunc]. ColdBrew provides a [default filter function] implementation that filters out common logs like healthcheck, readycheck, server reflection, etc.
 
-You can replace the default filter list using [SetFilterMethods]. This **overwrites** the entire list, so include the defaults if you want to keep them. Filter entries are matched as substrings against the lowercased method name — they work for both gRPC methods and HTTP paths:
+You can replace the default filter list using [SetFilterMethods]. This **overwrites** the entire list, so include the defaults if you want to keep them. Matching is **case-insensitive** (entries and method names are lowercased internally) and works for both gRPC methods and HTTP paths:
 
 ```go
 interceptors.SetFilterMethods(context.Background(), []string{
     "healthcheck", "readycheck", "serverreflectioninfo", // defaults
     "/echo",           // exclude HTTP path /echo
-    "MySvc/Echo",      // exclude gRPC method /com.github.ankurs.MySvc/Echo
+    "mysvc/echo",      // exclude gRPC method /com.github.ankurs.MySvc/Echo
 })
 ```
 
-For more advanced filtering, provide your own [FilterFunc] via [SetFilterFunc]. The function receives the request context, which lets you distinguish gRPC from HTTP requests. Return `true` to include a method in tracing/logging, or `false` to exclude it:
+For more advanced filtering, provide your own [FilterFunc] via [SetFilterFunc]. The function receives the **original-case** method name and the request context, which lets you distinguish gRPC from HTTP requests. Return `true` to include a method in tracing/logging, or `false` to exclude it:
 
 ```go
 interceptors.SetFilterFunc(context.Background(), func(ctx context.Context, method string) bool {

--- a/howto/interceptors.md
+++ b/howto/interceptors.md
@@ -28,34 +28,27 @@ ColdBrew uses interceptors to implement response time logging in [ResponseTimeLo
 
 It's possible to filter out response time log messages by using a [FilterFunc]. ColdBrew provides a [default filter function] implementation that filters out common logs like healthcheck, readycheck, server reflection, etc.
 
-You can set the filter list using [SetFilterMethods]. For example, to also filter out all methods containing `com.github.ankurs.MySvc/`:
+You can replace the default filter list using [SetFilterMethods]. This **overwrites** the entire list, so include the defaults if you want to keep them. Filter entries are matched as substrings against the lowercased method name — they work for both gRPC methods and HTTP paths:
 
 ```go
-import (
-    "context"
-    "github.com/go-coldbrew/interceptors"
-)
-
-func main() {
-    interceptors.SetFilterMethods(context.Background(), []string{
-        "healthcheck", "readycheck", "serverreflectioninfo",
-        "com.github.ankurs.MySvc/",
-    })
-}
+interceptors.SetFilterMethods(context.Background(), []string{
+    "healthcheck", "readycheck", "serverreflectioninfo", // defaults
+    "/echo",           // exclude HTTP path /echo
+    "MySvc/Echo",      // exclude gRPC method /com.github.ankurs.MySvc/Echo
+})
 ```
 
-You can also provide your own filter function by calling the [SetFilterFunc] variable:
+For more advanced filtering, provide your own [FilterFunc] via [SetFilterFunc]. The function receives the request context, which lets you distinguish gRPC from HTTP requests. Return `true` to include a method in tracing/logging, or `false` to exclude it:
 
 ```go
-import (
-    "github.com/go-coldbrew/interceptors"
-)
-
-func main() {
-    interceptors.SetFilterFunc(context.Background(), func(ctx context.Context, method string) bool {
-        return strings.HasPrefix(method, "com.github.ankurs.MySvc/")
-    })
-}
+interceptors.SetFilterFunc(context.Background(), func(ctx context.Context, method string) bool {
+    if _, ok := grpc.Method(ctx); ok {
+        // gRPC: only trace MyService methods
+        return strings.Contains(method, "MySvc")
+    }
+    // HTTP: trace everything except health and ready checks
+    return method != "/healthcheck" && method != "/readycheck"
+})
 ```
 
 ## Adding interceptors to your gRPC server

--- a/howto/interceptors.md
+++ b/howto/interceptors.md
@@ -28,15 +28,19 @@ ColdBrew uses interceptors to implement response time logging in [ResponseTimeLo
 
 It's possible to filter out response time log messages by using a [FilterFunc]. ColdBrew provides a [default filter function] implementation that filters out common logs like healthcheck, readycheck, server reflection, etc.
 
-You can add more methods to filter out by appending to the default [FilterMethods] list. For example, to filter out all methods that starts with `com.github.ankurs.MySvc/`:
+You can set the filter list using [SetFilterMethods]. For example, to also filter out all methods containing `com.github.ankurs.MySvc/`:
 
 ```go
 import (
+    "context"
     "github.com/go-coldbrew/interceptors"
 )
 
 func main() {
-    interceptors.FilterMethods = append(interceptors.FilterMethods, "com.github.ankurs.MySvc/")
+    interceptors.SetFilterMethods(context.Background(), []string{
+        "healthcheck", "readycheck", "serverreflectioninfo",
+        "com.github.ankurs.MySvc/",
+    })
 }
 ```
 
@@ -140,6 +144,7 @@ Use the function [AddUnaryServerInterceptor] and [AddUnaryClientInterceptor] to 
 [FilterFunc]: https://pkg.go.dev/github.com/go-coldbrew/interceptors#FilterFunc
 [default filter function]: https://pkg.go.dev/github.com/go-coldbrew/interceptors#FilterMethodsFunc
 [FilterMethods]: https://pkg.go.dev/github.com/go-coldbrew/interceptors#FilterMethods
+[SetFilterMethods]: https://pkg.go.dev/github.com/go-coldbrew/interceptors#SetFilterMethods
 [SetFilterFunc]: https://pkg.go.dev/github.com/go-coldbrew/interceptors#SetFilterFunc
 [AddUnaryServerInterceptor]: https://pkg.go.dev/github.com/go-coldbrew/interceptors#AddUnaryServerInterceptor
 [AddUnaryClientInterceptor]: https://pkg.go.dev/github.com/go-coldbrew/interceptors#AddUnaryClientInterceptor


### PR DESCRIPTION
## Summary
- **howto/interceptors.md**: Replace deprecated `FilterMethods = append(...)` with `SetFilterMethods(ctx, methods)` setter. Add `[SetFilterMethods]` reference link.
- **FAQ.md**: Fix `SetFilterFunc` example — add missing `context.Context` parameter and correct return value (`true` = don't filter).

## Test plan
- [ ] Verify docs site builds and pages render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated interceptor filtering configuration examples to support context-aware predicates.
  * Updated response-time logging filter configuration examples with revised API usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->