### PR TITLE
docs: add coldbrew.trace_id OTEL span attribute to architecture doc

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -199,7 +199,7 @@ Interceptors are gRPC middleware that run on every request. ColdBrew chains them
 | Order | Interceptor | Package | What It Does |
 |-------|------------|---------|--------------|
 | 1 | Response Time Logging | `interceptors` | Logs method name, duration, and status code |
-| 2 | Trace ID | `interceptors` | Generates a trace ID (or reads it from the `x-trace-id` HTTP header or a `trace_id` proto field) and propagates it to structured logs and Sentry/Rollbar error reports |
+| 2 | Trace ID | `interceptors` | Generates a trace ID (or reads it from the `x-trace-id` HTTP header or a `trace_id` proto field) and propagates it to structured logs, Sentry/Rollbar error reports, and OpenTelemetry spans (as the `coldbrew.trace_id` attribute) |
 | 3 | Prometheus | `interceptors` | Records request count, latency histogram, and status codes |
 | 4 | Error Notification | `interceptors` | Sends errors to Sentry/Rollbar/Airbrake asynchronously |
 | 5 | New Relic | `interceptors` | Creates a New Relic transaction for APM |
@@ -257,7 +257,7 @@ ColdBrew uses `context.Context` to propagate metadata through every layer:
        │
        └── trace ID (request correlation)
              Injected by: Trace ID interceptor
-             Available in: log output, error reports
+             Available in: log output, error reports, OTEL spans (coldbrew.trace_id attribute)
 ```
 
 Every interceptor reads from and writes to the context. By the time the request reaches your handler, the context carries:

--- a/architecture.md
+++ b/architecture.md
@@ -257,7 +257,7 @@ ColdBrew uses `context.Context` to propagate metadata through every layer:
        │
        └── trace ID (request correlation)
              Injected by: Trace ID interceptor
-             Available in: log output, error reports, OTEL spans (coldbrew.trace_id attribute)
+             Available in: log output, error reports, OpenTelemetry spans (`coldbrew.trace_id` attribute)
 ```
 
 Every interceptor reads from and writes to the context. By the time the request reaches your handler, the context carries:

--- a/howto/Tracing.md
+++ b/howto/Tracing.md
@@ -188,9 +188,9 @@ Once extracted, the trace ID is propagated to:
 | **Request context** | Stored in ColdBrew options | Accessible via `notifier.GetTraceId(ctx)` in your handler code |
 
 {: .note }
-ColdBrew's trace ID is separate from OpenTelemetry's W3C trace context. OpenTelemetry spans have their own trace/span IDs managed by the tracing SDK. ColdBrew's trace ID is a lightweight application-level correlation ID for logs and error reports. When an OTEL span is active, the trace ID is also set as the `coldbrew.trace_id` span attribute, connecting both systems.
+ColdBrew's trace ID is separate from OpenTelemetry's W3C trace context. OpenTelemetry spans have their own trace/span IDs managed by the tracing SDK. ColdBrew's trace ID is a lightweight application-level correlation ID for logs, error reports, and OTEL spans. When an OTEL span is active, the trace ID is set as the `coldbrew.trace_id` span attribute, connecting both systems.
 
-This means a single trace ID connects your logs and error reports — you can search for `req-abc-123` in your log aggregator and Sentry to find the complete request flow.
+This means a single trace ID connects your logs, error reports, and distributed traces — you can search for `req-abc-123` in your log aggregator, Sentry, or trace viewer to find the complete request flow.
 
 ### Customizing the header name
 

--- a/howto/Tracing.md
+++ b/howto/Tracing.md
@@ -184,10 +184,11 @@ Once extracted, the trace ID is propagated to:
 |-------------|-----|---------|
 | **Structured logs** | Added as `"trace"` field via log context | `{"level":"info","msg":"handled request","trace":"req-abc-123"}` |
 | **Sentry / Rollbar / Airbrake** | Attached to error notifications as a tag | Visible in the error report for correlation |
+| **OpenTelemetry spans** | Set as `coldbrew.trace_id` attribute on the active span | Links ColdBrew correlation ID to distributed traces |
 | **Request context** | Stored in ColdBrew options | Accessible via `notifier.GetTraceId(ctx)` in your handler code |
 
 {: .note }
-ColdBrew's trace ID is separate from OpenTelemetry's W3C trace context. OpenTelemetry spans have their own trace/span IDs managed by the tracing SDK. ColdBrew's trace ID is a lightweight application-level correlation ID for logs and error reports, derived from the incoming header or proto field, or generated randomly when none is provided.
+ColdBrew's trace ID is separate from OpenTelemetry's W3C trace context. OpenTelemetry spans have their own trace/span IDs managed by the tracing SDK. ColdBrew's trace ID is a lightweight application-level correlation ID for logs and error reports. When an OTEL span is active, the trace ID is also set as the `coldbrew.trace_id` span attribute, connecting both systems.
 
 This means a single trace ID connects your logs and error reports — you can search for `req-abc-123` in your log aggregator and Sentry to find the complete request flow.
 


### PR DESCRIPTION
## Summary
- **architecture.md**: Add `coldbrew.trace_id` OTEL span attribute to interceptor chain table and context diagram
- **howto/Tracing.md**: Add OpenTelemetry spans row to "Where the trace ID appears" table, update note to include spans

Closes #49

## Test plan
- [ ] Verify docs site renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture and tracing documentation to reflect trace ID integration with OpenTelemetry spans. Trace IDs are now explicitly set as the `coldbrew.trace_id` attribute on active spans, enhancing visibility across distributed tracing systems including logs, error reports, and trace viewers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->