### PR TITLE
docs: add Custom HTTP Routes section to APIs howto

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -102,6 +102,20 @@ This strongly prevents a documented endpoint that doesn't exist, an undocumented
 
 See [Self-Documenting APIs](/architecture#self-documenting-apis) for the full pipeline.
 
+## Can I add custom HTTP endpoints that aren't gRPC?
+
+Yes. ColdBrew is gRPC-first, but the grpc-gateway `runtime.ServeMux` passed to `InitHTTP` supports custom HTTP routes via `HandlePath`. You can register webhooks, file uploads, OAuth callbacks, or any raw HTTP handler alongside your gateway routes:
+
+```go
+mux.HandlePath("POST", "/webhooks/stripe", func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+    // raw HTTP — no proto marshalling
+})
+```
+
+These routes go through ColdBrew's HTTP middleware (compression, tracing, NewRelic) automatically.
+
+See [Custom HTTP Routes](/howto/APIs#custom-http-routes) for full examples including static file serving and path parameters.
+
 ## Is hystrixprometheus still maintained?
 
 **No.** The `hystrixprometheus` package depends on `afex/hystrix-go`, which is unmaintained. Do not invest in this package for new projects.

--- a/FAQ.md
+++ b/FAQ.md
@@ -107,14 +107,16 @@ See [Self-Documenting APIs](/architecture#self-documenting-apis) for the full pi
 Yes. ColdBrew is gRPC-first, but the grpc-gateway `runtime.ServeMux` passed to `InitHTTP` supports custom HTTP routes via `HandlePath`. You can register webhooks, file uploads, OAuth callbacks, or any raw HTTP handler alongside your gateway routes:
 
 ```go
-mux.HandlePath("POST", "/webhooks/stripe", func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+if err := mux.HandlePath("POST", "/webhooks/stripe", func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
     // raw HTTP — no proto marshalling
-})
+}); err != nil {
+    return err
+}
 ```
 
-These routes go through ColdBrew's HTTP middleware (compression, tracing, NewRelic) automatically.
+These routes go through ColdBrew's HTTP middleware (compression, tracing, New Relic) automatically.
 
-See [Custom HTTP Routes](/howto/APIs#custom-http-routes) for full examples including static file serving and path parameters.
+See [Custom HTTP Routes](/howto/APIs/#custom-http-routes) for full examples including static file serving and path parameters.
 
 ## Is hystrixprometheus still maintained?
 

--- a/howto/APIs.md
+++ b/howto/APIs.md
@@ -551,8 +551,16 @@ func (s *svc) InitHTTP(ctx context.Context, mux *runtime.ServeMux, endpoint stri
     // Custom HTTP routes
     if err := mux.HandlePath("POST", "/webhooks/stripe", func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
         // Handle Stripe webhook — raw HTTP, no proto marshalling
-        body, _ := io.ReadAll(r.Body)
-        // verify signature, process event...
+        body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1MB limit
+        if err != nil {
+            http.Error(w, "bad request", http.StatusBadRequest)
+            return
+        }
+        if !verifyStripeSignature(r.Header.Get("Stripe-Signature"), body) {
+            http.Error(w, "invalid signature", http.StatusForbidden)
+            return
+        }
+        processWebhookEvent(body)
         w.WriteHeader(http.StatusOK)
     }); err != nil {
         return err
@@ -568,15 +576,19 @@ Use the `{path=**}` wildcard to catch all sub-paths:
 
 ```go
 func (s *svc) InitHTTP(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
-    pb.RegisterMyServiceHandlerFromEndpoint(ctx, mux, endpoint, opts)
+    if err := pb.RegisterMyServiceHandlerFromEndpoint(ctx, mux, endpoint, opts); err != nil {
+        return err
+    }
 
     // Serve a React/Vue frontend from embedded files
     uiHandler := http.FileServer(http.FS(uiFiles))
-    mux.HandlePath("GET", "/ui/{path=**}", func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+    if err := mux.HandlePath("GET", "/ui/{path=**}", func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
         // Strip the /ui prefix
         r.URL.Path = "/" + pathParams["path"]
         uiHandler.ServeHTTP(w, r)
-    })
+    }); err != nil {
+        return err
+    }
 
     return nil
 }
@@ -585,11 +597,18 @@ func (s *svc) InitHTTP(ctx context.Context, mux *runtime.ServeMux, endpoint stri
 ### OAuth callback
 
 ```go
-mux.HandlePath("GET", "/auth/callback", func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+if err := mux.HandlePath("GET", "/auth/callback", func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
     code := r.URL.Query().Get("code")
-    // exchange code for token, set session...
+    token, err := exchangeCodeForToken(code)
+    if err != nil {
+        http.Error(w, "auth failed", http.StatusUnauthorized)
+        return
+    }
+    setSessionCookie(w, token)
     http.Redirect(w, r, "/", http.StatusFound)
-})
+}); err != nil {
+    return err
+}
 ```
 
 ### Path parameters
@@ -597,10 +616,18 @@ mux.HandlePath("GET", "/auth/callback", func(w http.ResponseWriter, r *http.Requ
 `HandlePath` supports path parameters using `{name}` syntax. Parameters are passed in the `pathParams` map:
 
 ```go
-mux.HandlePath("GET", "/files/{id}", func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+if err := mux.HandlePath("GET", "/files/{id}", func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
     fileID := pathParams["id"]
-    // serve file...
-})
+    data, err := s.storage.GetFile(r.Context(), fileID)
+    if err != nil {
+        http.Error(w, "not found", http.StatusNotFound)
+        return
+    }
+    w.Header().Set("Content-Type", "application/octet-stream")
+    w.Write(data)
+}); err != nil {
+    return err
+}
 ```
 
 {: .note }

--- a/howto/APIs.md
+++ b/howto/APIs.md
@@ -533,6 +533,82 @@ Instead of the default format:
 {: .note}
 For more advanced customization options, refer to the [grpc-gateway customization guide].
 
+## Custom HTTP Routes
+
+ColdBrew is gRPC-first, but sometimes you need HTTP endpoints that don't map to a gRPC method — webhooks, file uploads, OAuth callbacks, static file serving, or custom REST endpoints.
+
+The grpc-gateway `runtime.ServeMux` passed to `InitHTTP` supports custom routes via `HandlePath`. You can register any HTTP handler alongside your gateway routes:
+
+### Basic custom route
+
+```go
+func (s *svc) InitHTTP(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
+    // Register gateway routes (proto-generated)
+    if err := pb.RegisterMyServiceHandlerFromEndpoint(ctx, mux, endpoint, opts); err != nil {
+        return err
+    }
+
+    // Custom HTTP routes
+    if err := mux.HandlePath("POST", "/webhooks/stripe", func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+        // Handle Stripe webhook — raw HTTP, no proto marshalling
+        body, _ := io.ReadAll(r.Body)
+        // verify signature, process event...
+        w.WriteHeader(http.StatusOK)
+    }); err != nil {
+        return err
+    }
+
+    return nil
+}
+```
+
+### Serving static files or a UI
+
+Use the `{path=**}` wildcard to catch all sub-paths:
+
+```go
+func (s *svc) InitHTTP(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
+    pb.RegisterMyServiceHandlerFromEndpoint(ctx, mux, endpoint, opts)
+
+    // Serve a React/Vue frontend from embedded files
+    uiHandler := http.FileServer(http.FS(uiFiles))
+    mux.HandlePath("GET", "/ui/{path=**}", func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+        // Strip the /ui prefix
+        r.URL.Path = "/" + pathParams["path"]
+        uiHandler.ServeHTTP(w, r)
+    })
+
+    return nil
+}
+```
+
+### OAuth callback
+
+```go
+mux.HandlePath("GET", "/auth/callback", func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+    code := r.URL.Query().Get("code")
+    // exchange code for token, set session...
+    http.Redirect(w, r, "/", http.StatusFound)
+})
+```
+
+### Path parameters
+
+`HandlePath` supports path parameters using `{name}` syntax. Parameters are passed in the `pathParams` map:
+
+```go
+mux.HandlePath("GET", "/files/{id}", func(w http.ResponseWriter, r *http.Request, pathParams map[string]string) {
+    fileID := pathParams["id"]
+    // serve file...
+})
+```
+
+{: .note }
+Custom routes registered via `HandlePath` go through ColdBrew's HTTP middleware stack (compression, tracing, NewRelic) just like gateway routes. They benefit from the same observability without any extra configuration.
+
+{: .note }
+For routes that need to bypass the grpc-gateway marshalling entirely (e.g., streaming file uploads), `HandlePath` gives you raw `http.ResponseWriter` and `*http.Request` — no proto encoding/decoding involved.
+
 ---
 [google/rpc/status.proto]: https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto
 [google/rpc/code.proto]: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto

--- a/howto/APIs.md
+++ b/howto/APIs.md
@@ -544,7 +544,7 @@ The grpc-gateway `runtime.ServeMux` passed to `InitHTTP` supports custom routes 
 ```go
 func (s *svc) InitHTTP(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
     // Register gateway routes (proto-generated)
-    if err := pb.RegisterMyServiceHandlerFromEndpoint(ctx, mux, endpoint, opts); err != nil {
+    if err := proto.RegisterMyServiceHandlerFromEndpoint(ctx, mux, endpoint, opts); err != nil {
         return err
     }
 
@@ -576,7 +576,7 @@ Use the `{path=**}` wildcard to catch all sub-paths:
 
 ```go
 func (s *svc) InitHTTP(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) error {
-    if err := pb.RegisterMyServiceHandlerFromEndpoint(ctx, mux, endpoint, opts); err != nil {
+    if err := proto.RegisterMyServiceHandlerFromEndpoint(ctx, mux, endpoint, opts); err != nil {
         return err
     }
 
@@ -630,10 +630,10 @@ if err := mux.HandlePath("GET", "/files/{id}", func(w http.ResponseWriter, r *ht
 }
 ```
 
-{: .note }
-Custom routes registered via `HandlePath` go through ColdBrew's HTTP middleware stack (compression, tracing, NewRelic) just like gateway routes. They benefit from the same observability without any extra configuration.
+{: .note}
+Custom routes registered via `HandlePath` go through ColdBrew's HTTP middleware stack (compression, tracing, New Relic) just like gateway routes. They benefit from the same observability without any extra configuration.
 
-{: .note }
+{: .note}
 For routes that need to bypass the grpc-gateway marshalling entirely (e.g., streaming file uploads), `HandlePath` gives you raw `http.ResponseWriter` and `*http.Request` — no proto encoding/decoding involved.
 
 ---


### PR DESCRIPTION
## Summary
Add a new section to `howto/APIs.md` documenting custom HTTP routes via `mux.HandlePath`. Covers:
- Basic custom route (webhook example)
- Static file serving with `{path=**}` wildcard
- OAuth callback
- Path parameters

These routes go through ColdBrew's HTTP middleware stack (compression, tracing, NewRelic) automatically.

## Test plan
- [ ] Verify docs site renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Custom HTTP Routes" guide for registering non-gRPC HTTP handlers alongside existing endpoints.
  * Examples: webhook POSTs, serving static/UI via catch-all paths, OAuth callbacks with redirects, and path parameters.
  * Notes that these routes pass through the HTTP middleware for observability and can bypass gateway marshalling.
  * Added FAQ entry linking to the guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->