### PR TITLE
docs: add Metrics section to workers howto

### DIFF
--- a/howto/workers.md
+++ b/howto/workers.md
@@ -299,7 +299,9 @@ Workers support pluggable metrics via the `Metrics` interface. Pass metrics at t
 ### Built-in Prometheus metrics
 
 ```go
-workers.Run(ctx, myWorkers, workers.WithMetrics(workers.NewPrometheusMetrics("myapp")))
+if err := workers.Run(ctx, myWorkers, workers.WithMetrics(workers.NewPrometheusMetrics("myapp"))); err != nil {
+    log.Fatal(err)
+}
 ```
 
 This registers the following metrics (auto-registered via `promauto`):
@@ -319,7 +321,7 @@ This registers the following metrics (auto-registered via `promauto`):
 ### No metrics (default)
 
 ```go
-workers.Run(ctx, myWorkers) // uses BaseMetrics (no-op) — zero overhead
+_ = workers.Run(ctx, myWorkers) // uses BaseMetrics{} (no-op) — zero overhead
 ```
 
 ### Custom metrics
@@ -346,10 +348,15 @@ func (m *myDatadogMetrics) WorkerFailed(name string, err error) {
 
 ### Per-worker override
 
-Children inherit metrics from the root by default. Override for specific workers:
+Children inherit metrics from the root by default. Override for specific workers via the builder. Use `WorkerContext.Add` inside a manager worker:
 
 ```go
-ctx.Add(workers.NewWorker("special", fn).WithMetrics(customMetrics))
+workers.NewWorker("manager", func(ctx workers.WorkerContext) error {
+    // This child uses custom metrics instead of the inherited root metrics.
+    ctx.Add(workers.NewWorker("special", fn).WithMetrics(customMetrics))
+    <-ctx.Done()
+    return ctx.Err()
+})
 ```
 
 ## ColdBrew Integration (Phase 2)

--- a/howto/workers.md
+++ b/howto/workers.md
@@ -292,6 +292,60 @@ Worker lifecycle events (panics, restarts, backoff, timeouts) are logged via [go
 {"level":"info","msg":"worker resumed","event":"..."}
 ```
 
+## Metrics
+
+Workers support pluggable metrics via the `Metrics` interface. Pass metrics at the root level — all workers and their children inherit them automatically.
+
+### Built-in Prometheus metrics
+
+```go
+workers.Run(ctx, myWorkers, workers.WithMetrics(workers.NewPrometheusMetrics("myapp")))
+```
+
+This registers the following metrics (auto-registered via `promauto`):
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `myapp_worker_started_total{worker}` | Counter | Total worker starts |
+| `myapp_worker_stopped_total{worker}` | Counter | Total worker stops |
+| `myapp_worker_panicked_total{worker}` | Counter | Total worker panics |
+| `myapp_worker_failed_total{worker}` | Counter | Total worker failures |
+| `myapp_worker_restarted_total{worker}` | Counter | Total worker restarts |
+| `myapp_worker_run_duration_seconds{worker}` | Histogram | Duration of worker run cycles |
+| `myapp_worker_active_count` | Gauge | Currently active workers |
+
+`NewPrometheusMetrics` is safe to call multiple times with the same namespace — it returns the cached instance.
+
+### No metrics (default)
+
+```go
+workers.Run(ctx, myWorkers) // uses NoopMetrics — zero overhead
+```
+
+### Custom metrics
+
+Implement the `Metrics` interface for your own backend (Datadog, StatsD, etc.):
+
+```go
+type Metrics interface {
+    WorkerStarted(name string)
+    WorkerStopped(name string)
+    WorkerPanicked(name string)
+    WorkerFailed(name string, err error)
+    WorkerRestarted(name string, attempt int)
+    ObserveRunDuration(name string, duration time.Duration)
+    SetActiveWorkers(count int)
+}
+```
+
+### Per-worker override
+
+Children inherit metrics from the root by default. Override for specific workers:
+
+```go
+ctx.Add(workers.NewWorker("special", fn).WithMetrics(customMetrics))
+```
+
 ## ColdBrew Integration (Phase 2)
 
 The workers package is standalone — any Go service can use it. ColdBrew integration via `CBServiceV2` is planned for a future core release, where workers will be started/stopped as part of the ColdBrew service lifecycle.

--- a/howto/workers.md
+++ b/howto/workers.md
@@ -319,23 +319,29 @@ This registers the following metrics (auto-registered via `promauto`):
 ### No metrics (default)
 
 ```go
-workers.Run(ctx, myWorkers) // uses NoopMetrics — zero overhead
+workers.Run(ctx, myWorkers) // uses BaseMetrics (no-op) — zero overhead
 ```
 
 ### Custom metrics
 
-Implement the `Metrics` interface for your own backend (Datadog, StatsD, etc.):
+Implement the `Metrics` interface for your own backend (Datadog, StatsD, etc.). Embed `BaseMetrics` for forward compatibility — new methods added to the interface get safe no-op defaults instead of breaking your build:
 
 ```go
-type Metrics interface {
-    WorkerStarted(name string)
-    WorkerStopped(name string)
-    WorkerPanicked(name string)
-    WorkerFailed(name string, err error)
-    WorkerRestarted(name string, attempt int)
-    ObserveRunDuration(name string, duration time.Duration)
-    SetActiveWorkers(count int)
+type myDatadogMetrics struct {
+    workers.BaseMetrics // forward-compatible — new methods get no-op defaults
+    client *datadog.Client
 }
+
+func (m *myDatadogMetrics) WorkerStarted(name string) {
+    m.client.Incr("worker.started", []string{"worker:" + name}, 1)
+}
+
+func (m *myDatadogMetrics) WorkerFailed(name string, err error) {
+    m.client.Incr("worker.failed", []string{"worker:" + name}, 1)
+}
+
+// All other Metrics methods (Stopped, Panicked, Restarted, etc.)
+// default to no-op via BaseMetrics.
 ```
 
 ### Per-worker override


### PR DESCRIPTION
## Summary
Adds a Metrics section to the workers howto page covering:
- Built-in Prometheus metrics (table of all 7 metrics)
- NoopMetrics default (zero overhead)
- Custom Metrics interface for other backends
- Per-worker override with inheritance from root

## Test plan
- [ ] Playwright tests pass
- [ ] Workers howto page renders with new Metrics section