### PR TITLE
docs: shutdown lifecycle, DebugLogInterceptor, OverrideLogLevel + trace ID

### DIFF
--- a/config-reference.md
+++ b/config-reference.md
@@ -39,7 +39,7 @@ cfg := config.GetColdBrewConfig()
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `LOG_LEVEL` | string | `info` | Log level: debug, info, warn, error. For per-request debugging, use `log.OverrideLogLevel(ctx, loggers.DebugLevel)` — combined with the trace ID, this lets you enable debug logging for a single request and follow it across services. See [Log How-To](/howto/Log/#overriding-log-level-at-request-time) |
+| `LOG_LEVEL` | string | `info` | Log level: debug, info, warn, error. For per-request debugging, use `log.OverrideLogLevel(ctx, loggers.DebugLevel)` — combined with the trace ID, this lets you enable debug logging for a single request and follow it across services. See [Log How-To](/howto/Log/#production-debugging-with-overrideloglevel--trace-id) |
 | `JSON_LOGS` | bool | `true` | Emit logs in JSON format |
 
 ## gRPC Server

--- a/config-reference.md
+++ b/config-reference.md
@@ -39,7 +39,7 @@ cfg := config.GetColdBrewConfig()
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `LOG_LEVEL` | string | `info` | Log level: debug, info, warn, error |
+| `LOG_LEVEL` | string | `info` | Log level: debug, info, warn, error. For per-request debugging, use `log.OverrideLogLevel(ctx, loggers.DebugLevel)` — combined with the trace ID, this lets you enable debug logging for a single request and follow it across services. See [Log How-To](/howto/Log/#overriding-log-level-at-request-time) |
 | `JSON_LOGS` | bool | `true` | Emit logs in JSON format |
 
 ## gRPC Server
@@ -52,6 +52,8 @@ cfg := config.GetColdBrewConfig()
 | `GRPC_MAX_RECV_MSG_SIZE` | int | `4194304` | Maximum receive message size in bytes (default: 4MB) |
 | `DISABLE_VT_PROTOBUF` | bool | `false` | Disable [vtprotobuf](https://github.com/planetscale/vtprotobuf) marshaller for gRPC. See [vtprotobuf guide](/howto/vtproto) |
 | `DISABLE_PROTO_VALIDATE` | bool | `false` | Disable [protovalidate](https://github.com/bufbuild/protovalidate) interceptor. When disabled, proto validation annotations are ignored |
+| `DISABLE_DEBUG_LOG_INTERCEPTOR` | bool | `false` | Disable the DebugLogInterceptor. When disabled, proto `debug`/`enable_debug` fields and `x-debug-log-level` headers will not trigger per-request debug logging |
+| `DEBUG_LOG_HEADER_NAME` | string | `x-debug-log-level` | gRPC metadata / HTTP header name for per-request debug logging. The header value should be a valid log level (`debug`, `info`, `warn`, `error`). See [Log How-To](/howto/Log/#production-debugging-with-overrideloglevel--trace-id) |
 | `GRPC_SERVER_DEFAULT_TIMEOUT_IN_SECONDS` | int | `60` | Default timeout for incoming unary gRPC requests without a deadline. Set to `0` to disable. Does not apply to stream RPCs |
 
 ## gRPC TLS

--- a/howto/Log.md
+++ b/howto/Log.md
@@ -184,6 +184,41 @@ Will output the debug log messages even when the global log level is set to info
 {"level":"debug","msg":"Hello World","request-id":"1234","trace":"5678","user-id":"abcd","@timestamp":"2020-05-04T15:04:05.000Z"}
 ```
 
+### Production debugging with OverrideLogLevel + trace ID
+
+ColdBrew's `DebugLogInterceptor` (enabled by default) automatically enables per-request debug logging when it detects:
+
+1. **A proto field** — `bool debug = N` or `bool enable_debug = N` in the request message
+2. **A metadata/HTTP header** — `x-debug-log-level: debug` (configurable via `DEBUG_LOG_HEADER_NAME`)
+
+Combined with ColdBrew's automatic trace ID propagation, this lets you enable debug logging for a single request and follow it end-to-end across services via the trace ID.
+
+**Why this is better than changing the global `LOG_LEVEL`:**
+- **Zero blast radius** — only the targeted request gets debug logs; other requests stay at INFO
+- **Works across services** — the trace ID follows the request through downstream gRPC calls
+- **No restart needed** — the override is per-request, not per-process
+
+**Proto field approach** (implicit — ColdBrew detects it automatically):
+
+```protobuf
+message MyRequest {
+    string msg = 1;
+    bool debug = 2;  // ColdBrew reads this automatically
+}
+```
+
+**Header approach** (works with both gRPC and HTTP):
+
+```bash
+# gRPC
+grpcurl -H "x-debug-log-level: debug" localhost:9090 myservice.MyService/MyMethod
+
+# HTTP (via grpc-gateway)
+curl -H "x-debug-log-level: debug" http://localhost:9091/api/v1/echo
+```
+
+See the [interceptors howto](/howto/interceptors) for configuration options and the [config reference](/config-reference) for `DISABLE_DEBUG_LOG_INTERCEPTOR` and `DEBUG_LOG_HEADER_NAME`.
+
 ---
 [TraceId interceptor]: https://pkg.go.dev/github.com/go-coldbrew/interceptors#TraceIdInterceptor
 [go-coldbrew/tracing]: https://pkg.go.dev/github.com/go-coldbrew/tracing

--- a/howto/Log.md
+++ b/howto/Log.md
@@ -217,7 +217,7 @@ grpcurl -H "x-debug-log-level: debug" localhost:9090 myservice.MyService/MyMetho
 curl -H "x-debug-log-level: debug" http://localhost:9091/api/v1/echo
 ```
 
-See the [interceptors howto](/howto/interceptors) for configuration options and the [config reference](/config-reference) for `DISABLE_DEBUG_LOG_INTERCEPTOR` and `DEBUG_LOG_HEADER_NAME`.
+See the [config reference](/config-reference) for `DISABLE_DEBUG_LOG_INTERCEPTOR` and `DEBUG_LOG_HEADER_NAME` settings.
 
 ---
 [TraceId interceptor]: https://pkg.go.dev/github.com/go-coldbrew/interceptors#TraceIdInterceptor

--- a/howto/production.md
+++ b/howto/production.md
@@ -174,15 +174,16 @@ Set `terminationGracePeriodSeconds` to at least `SHUTDOWN_DURATION_IN_SECONDS` +
 
 ## Graceful shutdown tuning
 
-ColdBrew's shutdown sequence:
+ColdBrew's shutdown sequence (bounded by `SHUTDOWN_DURATION_IN_SECONDS`, default 15s):
 
 1. Receive SIGTERM from Kubernetes
 2. `FailCheck(true)` on `CBGracefulStopper` services — `/readycheck` starts failing
-3. Wait `GRPC_GRACEFUL_DURATION_IN_SECONDS` (default: 7s) for the load balancer to drain
+3. Wait `GRPC_GRACEFUL_DURATION_IN_SECONDS` (default: 7s, included in shutdown timeout) for the load balancer to drain
 4. Shutdown HTTP server (stop accepting new requests)
 5. `GracefulStop()` gRPC server (finish in-flight RPCs, reject new ones)
-6. Call `Stop()` on `CBStopper` services — close database pools, flush metrics, drain message producers
-7. Exit
+6. Force-stop gRPC server if graceful shutdown didn't complete in time
+7. Call `Stop()` on `CBStopper` services — close database pools, flush metrics, drain message producers
+8. Exit
 
 For details on each step and cleanup examples, see [Signal Handling and Graceful Shutdown](/howto/signals).
 

--- a/howto/production.md
+++ b/howto/production.md
@@ -177,12 +177,14 @@ Set `terminationGracePeriodSeconds` to at least `SHUTDOWN_DURATION_IN_SECONDS` +
 ColdBrew's shutdown sequence:
 
 1. Receive SIGTERM from Kubernetes
-2. Fail `/readycheck` immediately
+2. `FailCheck(true)` on `CBGracefulStopper` services — `/readycheck` starts failing
 3. Wait `GRPC_GRACEFUL_DURATION_IN_SECONDS` (default: 7s) for the load balancer to drain
-4. Stop accepting new requests
-5. Wait `SHUTDOWN_DURATION_IN_SECONDS` (default: 15s) for in-flight requests to complete
-6. Call `Stop()` if your service implements `CBStopper`
+4. Shutdown HTTP server (stop accepting new requests)
+5. `GracefulStop()` gRPC server (finish in-flight RPCs, reject new ones)
+6. Call `Stop()` on `CBStopper` services — close database pools, flush metrics, drain message producers
 7. Exit
+
+For details on each step and cleanup examples, see [Signal Handling and Graceful Shutdown](/howto/signals).
 
 Tune these values based on your service:
 

--- a/howto/signals.md
+++ b/howto/signals.md
@@ -41,8 +41,8 @@ When the application receives a signal, ColdBrew executes a multi-step shutdown 
 
 Configuring the shutdown process is done by setting the [config] values:
 
-- `SHUTDOWN_DURATION_IN_SECONDS` - Total shutdown timeout (default: 15s). After this, the process exits regardless.
-- `GRPC_GRACEFUL_DURATION_IN_SECONDS` - How long to wait after failing `/readycheck` before stopping servers (default: 7s). This gives the load balancer time to drain.
+- `SHUTDOWN_DURATION_IN_SECONDS` - Timeout for the entire `Stop()` sequence (default: 15s), covering steps 2-7 above including the drain wait. After this, the process exits regardless.
+- `GRPC_GRACEFUL_DURATION_IN_SECONDS` - Duration of step 2 — how long to wait after failing `/readycheck` before stopping servers (default: 7s). This is **included within** `SHUTDOWN_DURATION_IN_SECONDS`, not additional to it.
 - `DISABLE_SIGNAL_HANDLER` - If set to `true`, ColdBrew will not register a signal handler (useful when you want to handle signals yourself).
 
 ## Service lifecycle interfaces

--- a/howto/signals.md
+++ b/howto/signals.md
@@ -27,26 +27,50 @@ When you start your application, ColdBrew will register a signal handler for `SI
 
 ## Graceful shutdown
 
-When the application receives a signal, it will start a graceful shutdown process. This process will do the following:
+When the application receives a signal, ColdBrew executes a multi-step shutdown sequence:
 
-  1. Fail the readiness check
-  2. Wait for all requests to finish
-  3. Shutdown the application when all requests are finished or after a timeout
+1. **`FailCheck(true)`** on services implementing [CBGracefulStopper] — `/readycheck` starts returning failure
+2. **Wait** `GRPC_GRACEFUL_DURATION_IN_SECONDS` (default: 7s) for the load balancer to stop sending traffic
+3. **Shutdown HTTP server** — stop accepting new HTTP requests
+4. **`GracefulStop()` gRPC server** — finish in-flight RPCs, reject new ones
+5. **Force-stop gRPC server** if graceful shutdown didn't complete in time
+6. **`Stop()`** on services implementing [CBStopper] — resource cleanup
+7. **Exit**
 
 ## Customizing the shutdown process
 
 Configuring the shutdown process is done by setting the [config] values:
 
-- `SHUTDOWN_DURATION_IN_SECONDS` - The duration in seconds to wait for all requests to finish before shutting down the application.
-- `GRPC_GRACEFUL_DURATION_IN_SECONDS` - The duration in seconds for which ColdBrew will wait for propagation of readiness check failure to the load balancer.
-- `DISABLE_SIGNAL_HANDLER` - If set to `true`, ColdBrew will not register a signal handler (this is useful when you want to handle signals yourself).
+- `SHUTDOWN_DURATION_IN_SECONDS` - Total shutdown timeout (default: 15s). After this, the process exits regardless.
+- `GRPC_GRACEFUL_DURATION_IN_SECONDS` - How long to wait after failing `/readycheck` before stopping servers (default: 7s). This gives the load balancer time to drain.
+- `DISABLE_SIGNAL_HANDLER` - If set to `true`, ColdBrew will not register a signal handler (useful when you want to handle signals yourself).
+
+## Service lifecycle interfaces
+
+ColdBrew provides two optional interfaces for shutdown behavior:
+
+| Interface | Method | When called | Use for |
+|-----------|--------|-------------|---------|
+| [CBGracefulStopper] | `FailCheck(bool)` | **First** — before drain wait | Mark service as not ready |
+| [CBStopper] | `Stop()` | **Last** — after all servers stopped | Close DB pools, flush metrics, drain producers |
+
+{: .important}
+All resource cleanup belongs in `Stop()`. ColdBrew calls it after all servers have stopped and in-flight requests have completed (or timed out).
 
 ## Cleanup before shutdown
 
-If your service implements [CBStopper] interface, ColdBrew will call the `Stop` method when the application is shutting down. This is useful if you want to perform some cleanup before the application shuts down.
+Implement the [CBStopper] interface to clean up resources during shutdown:
 
-{: .important}
-ColdBrew will call the `Stop` method after all requests have finished or after the `SHUTDOWN_DURATION_IN_SECONDS` timeout has expired.
+```go
+func (s *svc) Stop() {
+    s.dbPool.Close()           // close database connections
+    s.redisClient.Close()      // close Redis
+    s.metricsReporter.Flush()  // flush pending metrics
+    s.kafkaProducer.Close()    // drain and close Kafka producer
+}
+```
+
+The [ColdBrew cookiecutter] generates this pattern — your service struct implements `CBStopper` and delegates to the service implementation's `Stop()` method.
 
 ## Kubernetes liveness and readiness probes
 
@@ -65,5 +89,6 @@ Make sure you configure your load balancer to stop sending new requests to your 
 [go-coldbrew/core]: https://pkg.go.dev/github.com/go-coldbrew/core
 [config]: https://pkg.go.dev/github.com/go-coldbrew/core/config#Config
 [CBStopper]: https://pkg.go.dev/github.com/go-coldbrew/core#CBStopper
+[CBGracefulStopper]: https://pkg.go.dev/github.com/go-coldbrew/core#CBGracefulStopper
 [Kubernetes]: https://kubernetes.io/
 [POSIX signals]: https://en.wikipedia.org/wiki/Signal_(IPC)#POSIX_signals


### PR DESCRIPTION
## Summary

**Shutdown docs:**
- Expand signals.md with full 7-step shutdown sequence (was oversimplified to 3 steps)
- Add `CBGracefulStopper` vs `CBStopper` comparison table with when-to-use guidance
- Add concrete `Stop()` cleanup examples (DB, Redis, metrics, Kafka)
- Update production.md shutdown sequence to match

**Debug logging docs:**
- Add `DebugLogInterceptor` + trace ID production debugging pattern to Log.md
- Document proto field and header approaches for per-request debug logging
- Add `DISABLE_DEBUG_LOG_INTERCEPTOR` and `DEBUG_LOG_HEADER_NAME` to config reference
- Add `OverrideLogLevel` + trace ID note to `LOG_LEVEL` config entry

## Test plan
- [x] No permalink changes — navigation tests unaffected
- [x] All links reference existing pages/anchors