### PR TITLE
docs: add security hardening guide to production page

### DIFF
--- a/config-reference.md
+++ b/config-reference.md
@@ -39,7 +39,7 @@ cfg := config.GetColdBrewConfig()
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `LOG_LEVEL` | string | `info` | Log level: debug, info, warn, error. For per-request debugging, use `log.OverrideLogLevel(ctx, loggers.DebugLevel)` — combined with the trace ID, this lets you enable debug logging for a single request and follow it across services. See [Log How-To](/howto/Log/#overriding-log-level-at-request-time) |
+| `LOG_LEVEL` | string | `info` | Log level: debug, info, warn, error. For per-request debugging, use `log.OverrideLogLevel(ctx, loggers.DebugLevel)` — combined with the trace ID, this lets you enable debug logging for a single request and follow it across services. See [Log How-To](/howto/Log/#production-debugging-with-overrideloglevel--trace-id) |
 | `JSON_LOGS` | bool | `true` | Emit logs in JSON format |
 
 ## gRPC Server

--- a/config-reference.md
+++ b/config-reference.md
@@ -48,8 +48,8 @@ cfg := config.GetColdBrewConfig()
 |----------|------|---------|-------------|
 | `DISABLE_GRPC_REFLECTION` | bool | `false` | Disable gRPC server reflection (used by tools like grpcurl) |
 | `DO_NOT_LOG_GRPC_REFLECTION` | bool | `true` | Suppress logging of gRPC reflection API calls |
-| `GRPC_MAX_SEND_MSG_SIZE` | int | `2147483647` | Maximum send message size in bytes (default: ~2GB, unlimited) |
-| `GRPC_MAX_RECV_MSG_SIZE` | int | `4194304` | Maximum receive message size in bytes (default: 4MB) |
+| `GRPC_MAX_SEND_MSG_SIZE` | int | `2147483647` | Maximum **response** size in bytes — limits how large a response your service can send back to clients (default: ~2GB). Consider reducing for public-facing services; use streaming RPCs for large payloads |
+| `GRPC_MAX_RECV_MSG_SIZE` | int | `4194304` | Maximum **request** size in bytes — limits how large a request your service accepts from clients (default: 4MB) |
 | `DISABLE_VT_PROTOBUF` | bool | `false` | Disable [vtprotobuf](https://github.com/planetscale/vtprotobuf) marshaller for gRPC. See [vtprotobuf guide](/howto/vtproto) |
 | `DISABLE_PROTO_VALIDATE` | bool | `false` | Disable [protovalidate](https://github.com/bufbuild/protovalidate) interceptor. When disabled, proto validation annotations are ignored |
 | `DISABLE_DEBUG_LOG_INTERCEPTOR` | bool | `false` | Disable the DebugLogInterceptor. When disabled, proto `debug`/`enable_debug` fields and `x-debug-log-level` headers will not trigger per-request debug logging |

--- a/config-reference.md
+++ b/config-reference.md
@@ -39,7 +39,7 @@ cfg := config.GetColdBrewConfig()
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `LOG_LEVEL` | string | `info` | Log level: debug, info, warn, error |
+| `LOG_LEVEL` | string | `info` | Log level: debug, info, warn, error. For per-request debugging, use `log.OverrideLogLevel(ctx, loggers.DebugLevel)` — combined with the trace ID, this lets you enable debug logging for a single request and follow it across services. See [Log How-To](/howto/Log/#overriding-log-level-at-request-time) |
 | `JSON_LOGS` | bool | `true` | Emit logs in JSON format |
 
 ## gRPC Server
@@ -52,6 +52,8 @@ cfg := config.GetColdBrewConfig()
 | `GRPC_MAX_RECV_MSG_SIZE` | int | `4194304` | Maximum receive message size in bytes (default: 4MB) |
 | `DISABLE_VT_PROTOBUF` | bool | `false` | Disable [vtprotobuf](https://github.com/planetscale/vtprotobuf) marshaller for gRPC. See [vtprotobuf guide](/howto/vtproto) |
 | `DISABLE_PROTO_VALIDATE` | bool | `false` | Disable [protovalidate](https://github.com/bufbuild/protovalidate) interceptor. When disabled, proto validation annotations are ignored |
+| `DISABLE_DEBUG_LOG_INTERCEPTOR` | bool | `false` | Disable the DebugLogInterceptor. When disabled, proto `debug`/`enable_debug` fields and `x-debug-log-level` headers will not trigger per-request debug logging |
+| `DEBUG_LOG_HEADER_NAME` | string | `x-debug-log-level` | gRPC metadata / HTTP header name for per-request debug logging. The header value should be a valid log level (`debug`, `info`, `warn`, `error`). See [Log How-To](/howto/Log/#production-debugging-with-overrideloglevel--trace-id) |
 | `GRPC_SERVER_DEFAULT_TIMEOUT_IN_SECONDS` | int | `60` | Default timeout for incoming unary gRPC requests without a deadline. Set to `0` to disable. Does not apply to stream RPCs |
 
 ## gRPC TLS

--- a/howto/Log.md
+++ b/howto/Log.md
@@ -184,6 +184,41 @@ Will output the debug log messages even when the global log level is set to info
 {"level":"debug","msg":"Hello World","request-id":"1234","trace":"5678","user-id":"abcd","@timestamp":"2020-05-04T15:04:05.000Z"}
 ```
 
+### Production debugging with OverrideLogLevel + trace ID
+
+ColdBrew's `DebugLogInterceptor` (enabled by default) automatically enables per-request debug logging when it detects:
+
+1. **A proto field** — `bool debug = N` or `bool enable_debug = N` in the request message
+2. **A metadata/HTTP header** — `x-debug-log-level: debug` (configurable via `DEBUG_LOG_HEADER_NAME`)
+
+Combined with ColdBrew's automatic trace ID propagation, this lets you enable debug logging for a single request and follow it end-to-end across services via the trace ID.
+
+**Why this is better than changing the global `LOG_LEVEL`:**
+- **Zero blast radius** — only the targeted request gets debug logs; other requests stay at INFO
+- **Works across services** — the trace ID follows the request through downstream gRPC calls
+- **No restart needed** — the override is per-request, not per-process
+
+**Proto field approach** (implicit — ColdBrew detects it automatically):
+
+```protobuf
+message MyRequest {
+    string msg = 1;
+    bool debug = 2;  // ColdBrew reads this automatically
+}
+```
+
+**Header approach** (works with both gRPC and HTTP):
+
+```bash
+# gRPC
+grpcurl -H "x-debug-log-level: debug" localhost:9090 myservice.MyService/MyMethod
+
+# HTTP (via grpc-gateway)
+curl -H "x-debug-log-level: debug" http://localhost:9091/api/v1/echo
+```
+
+See the [interceptors howto](/howto/interceptors) for configuration options and the [config reference](/config-reference) for `DISABLE_DEBUG_LOG_INTERCEPTOR` and `DEBUG_LOG_HEADER_NAME`.
+
 ---
 [TraceId interceptor]: https://pkg.go.dev/github.com/go-coldbrew/interceptors#TraceIdInterceptor
 [go-coldbrew/tracing]: https://pkg.go.dev/github.com/go-coldbrew/tracing

--- a/howto/Log.md
+++ b/howto/Log.md
@@ -217,7 +217,7 @@ grpcurl -H "x-debug-log-level: debug" localhost:9090 myservice.MyService/MyMetho
 curl -H "x-debug-log-level: debug" http://localhost:9091/api/v1/echo
 ```
 
-See the [interceptors howto](/howto/interceptors) for configuration options and the [config reference](/config-reference) for `DISABLE_DEBUG_LOG_INTERCEPTOR` and `DEBUG_LOG_HEADER_NAME`.
+See the [config reference](/config-reference) for `DISABLE_DEBUG_LOG_INTERCEPTOR` and `DEBUG_LOG_HEADER_NAME` settings.
 
 ---
 [TraceId interceptor]: https://pkg.go.dev/github.com/go-coldbrew/interceptors#TraceIdInterceptor

--- a/howto/production.md
+++ b/howto/production.md
@@ -174,15 +174,16 @@ Set `terminationGracePeriodSeconds` to at least `SHUTDOWN_DURATION_IN_SECONDS` +
 
 ## Graceful shutdown tuning
 
-ColdBrew's shutdown sequence:
+ColdBrew's shutdown sequence (bounded by `SHUTDOWN_DURATION_IN_SECONDS`, default 15s):
 
 1. Receive SIGTERM from Kubernetes
 2. `FailCheck(true)` on `CBGracefulStopper` services — `/readycheck` starts failing
-3. Wait `GRPC_GRACEFUL_DURATION_IN_SECONDS` (default: 7s) for the load balancer to drain
+3. Wait `GRPC_GRACEFUL_DURATION_IN_SECONDS` (default: 7s, included in shutdown timeout) for the load balancer to drain
 4. Shutdown HTTP server (stop accepting new requests)
 5. `GracefulStop()` gRPC server (finish in-flight RPCs, reject new ones)
-6. Call `Stop()` on `CBStopper` services — close database pools, flush metrics, drain message producers
-7. Exit
+6. Force-stop gRPC server if graceful shutdown didn't complete in time
+7. Call `Stop()` on `CBStopper` services — close database pools, flush metrics, drain message producers
+8. Exit
 
 For details on each step and cleanup examples, see [Signal Handling and Graceful Shutdown](/howto/signals).
 

--- a/howto/production.md
+++ b/howto/production.md
@@ -185,8 +185,6 @@ ColdBrew's shutdown sequence (bounded by `SHUTDOWN_DURATION_IN_SECONDS`, default
 7. Call `Stop()` on `CBStopper` services — close database pools, flush metrics, drain message producers
 8. Exit
 
-For details on each step and cleanup examples, see [Signal Handling and Graceful Shutdown](/howto/signals).
-
 Tune these values based on your service:
 
 ```yaml
@@ -455,7 +453,7 @@ ColdBrew's defaults are tuned for **internal services** — debug endpoints, API
 Services exposed to external traffic (API gateways, user-facing endpoints) should whitelist only the API paths that need to be public and disable discovery and debug features:
 
 {: .important }
-The most effective security measure is to **whitelist public API paths** at your load balancer or reverse proxy and block everything else. ColdBrew serves gRPC, HTTP gateway, debug, metrics, and swagger all on the same HTTP port. Only your application's API routes (e.g., `/api/v1/*`) should be exposed externally — block `/debug/*`, `/metrics`, `/swagger/*`, and any other internal paths at the infrastructure level.
+The most effective security measure is to **whitelist public API paths** at your load balancer or reverse proxy and block everything else. ColdBrew serves the HTTP gateway, debug, metrics, and swagger on the HTTP port (default 9091) and gRPC on a separate port (default 9090). Only your application's API routes (e.g., `/api/v1/*`) should be exposed externally — block `/debug/*`, `/metrics`, `/swagger/*`, and any other internal paths at the infrastructure level.
 
 ```yaml
 env:

--- a/howto/production.md
+++ b/howto/production.md
@@ -177,12 +177,14 @@ Set `terminationGracePeriodSeconds` to at least `SHUTDOWN_DURATION_IN_SECONDS` +
 ColdBrew's shutdown sequence:
 
 1. Receive SIGTERM from Kubernetes
-2. Fail `/readycheck` immediately
+2. `FailCheck(true)` on `CBGracefulStopper` services — `/readycheck` starts failing
 3. Wait `GRPC_GRACEFUL_DURATION_IN_SECONDS` (default: 7s) for the load balancer to drain
-4. Stop accepting new requests
-5. Wait `SHUTDOWN_DURATION_IN_SECONDS` (default: 15s) for in-flight requests to complete
-6. Call `Stop()` if your service implements `CBStopper`
+4. Shutdown HTTP server (stop accepting new requests)
+5. `GracefulStop()` gRPC server (finish in-flight RPCs, reject new ones)
+6. Call `Stop()` on `CBStopper` services — close database pools, flush metrics, drain message producers
 7. Exit
+
+For details on each step and cleanup examples, see [Signal Handling and Graceful Shutdown](/howto/signals).
 
 Tune these values based on your service:
 

--- a/howto/production.md
+++ b/howto/production.md
@@ -443,7 +443,102 @@ env:
     value: "3600"
 ```
 
+## Security hardening
+
+{: .warning }
+This section provides general security guidance for ColdBrew configuration. Always follow your organization's security policies and compliance requirements. ColdBrew is a framework — securing your deployment is your responsibility.
+
+ColdBrew's defaults are tuned for **internal services** — debug endpoints, API docs, and gRPC reflection are enabled by default. Public-facing services need different settings.
+
+### Public-facing services
+
+Services exposed to external traffic (API gateways, user-facing endpoints) should whitelist only the API paths that need to be public and disable discovery and debug features:
+
+{: .important }
+The most effective security measure is to **whitelist public API paths** at your load balancer or reverse proxy and block everything else. ColdBrew serves gRPC, HTTP gateway, debug, metrics, and swagger all on the same HTTP port. Only your application's API routes (e.g., `/api/v1/*`) should be exposed externally — block `/debug/*`, `/metrics`, `/swagger/*`, and any other internal paths at the infrastructure level.
+
+```yaml
+env:
+  # Disable pprof — exposes CPU/memory profiling data
+  - name: DISABLE_DEBUG
+    value: "true"
+  # Disable Swagger UI — exposes API schema and endpoint discovery
+  - name: DISABLE_SWAGGER
+    value: "true"
+  # Disable gRPC reflection — prevents service discovery via grpcurl
+  - name: DISABLE_GRPC_REFLECTION
+    value: "true"
+  # Disable debug log interceptor — prevents external clients from
+  # triggering debug logging via x-debug-log-level header
+  - name: DISABLE_DEBUG_LOG_INTERCEPTOR
+    value: "true"
+  # Never use debug level on public services — may log request payloads
+  - name: LOG_LEVEL
+    value: "info"
+  # GRPC_MAX_SEND_MSG_SIZE limits response size FROM your service (default ~2GB).
+  # GRPC_MAX_RECV_MSG_SIZE limits request size TO your service (default 4MB).
+  # Consider reducing send size for public APIs; use streaming for large payloads.
+  # - name: GRPC_MAX_SEND_MSG_SIZE
+  #   value: "16777216"  # 16MB
+```
+
+{: .important }
+The `/metrics` endpoint exposes request counts, latency distributions, and Go runtime stats. For public-facing services, restrict access to `/metrics` at the load balancer level (IP whitelist or path-based routing) rather than disabling Prometheus entirely.
+
+### Internal services
+
+Services behind a load balancer or service mesh can keep the defaults:
+
+- **Debug endpoints** (`/debug/pprof/`) — useful for profiling production issues
+- **Swagger UI** (`/swagger/`) — API documentation for developers
+- **gRPC reflection** — enables `grpcurl` and `grpcui` for ad-hoc testing
+- **Debug log interceptor** — `OverrideLogLevel` + trace ID for targeted production debugging (see [Log How-To](/howto/Log/#production-debugging-with-overrideloglevel--trace-id))
+- **Default message sizes** — ~2GB send (response) / 4MB recv (request) defaults are fine behind a load balancer
+
+{: .note }
+Internal services should still follow the production checklist below for observability, health probes, and graceful shutdown.
+
+### Built-in protections
+
+ColdBrew includes several security features that are **on by default**. Don't disable them unless you have a specific reason:
+
+| Protection | What it does | Config to disable (not recommended) |
+|-----------|-------------|--------------------------------------|
+| **Trace ID validation** | Sanitizes client-supplied trace IDs — max 128 chars, printable ASCII only. Prevents log injection attacks | `SetTraceIDValidator(nil)` in code |
+| **Protovalidate** | Validates incoming messages against proto annotation rules. Returns `InvalidArgument` on failure | `DISABLE_PROTO_VALIDATE=true` |
+| **Default timeout** | 60s deadline on unary RPCs without one. Prevents slowloris and resource exhaustion | `GRPC_SERVER_DEFAULT_TIMEOUT_IN_SECONDS=0` |
+| **Panic recovery** | Catches handler panics, returns generic error to client. Stack traces go to logs and error trackers only — never in gRPC responses | Cannot be disabled |
+
+### Data sent to third-party services
+
+{: .important }
+When error tracking (Sentry, Rollbar) or distributed tracing (New Relic, OTLP) is configured, ColdBrew sends data to external services. Review what your service logs before enabling these on public-facing services.
+
+**What gets sent to error trackers (Sentry, Rollbar, Airbrake):**
+- Stack traces with internal file paths and function names
+- Server hostname and git commit hash
+- Log context fields — any data added via `log.AddToLogContext()` is included
+- Trace IDs and OTEL span context
+
+**What gets sent to tracing backends (New Relic, OTLP):**
+- Service name, version, environment
+- Go runtime version and VCS metadata
+- Span attributes including `coldbrew.trace_id`
+
+Avoid adding PII (passwords, tokens, user data) to log context or error notification tags.
+
+### Not built into ColdBrew
+
+These are your responsibility to handle at the infrastructure level:
+
+- **CORS** — ColdBrew does not handle CORS headers. Use a reverse proxy (Nginx, Envoy, Istio) or add CORS middleware to the HTTP gateway.
+- **Authentication/authorization** — Admin endpoints (`/debug/pprof`, `/metrics`, `/swagger`) have no built-in auth. Disable them for public services or restrict access at the load balancer.
+- **Rate limiting** — No built-in rate limiting on any endpoint. Use your load balancer, service mesh, or a rate-limiting proxy.
+- **HTTP header forwarding** — `HTTP_HEADER_PREFIXES` forwards matching HTTP headers to gRPC metadata. Never add `authorization`, `cookie`, or `x-api-key` prefixes unless you are intentionally doing header-based gRPC auth.
+
 ## Production checklist
+
+### All services
 
 - [ ] Set `APP_NAME` and `ENVIRONMENT` for log/metric identification
 - [ ] Configure `livenessProbe` on `/healthcheck` and `readinessProbe` on `/readycheck`
@@ -454,9 +549,19 @@ env:
 - [ ] Use headless Service or L7 proxy for gRPC load balancing
 - [ ] Set resource requests and limits
 - [ ] Store secrets in Kubernetes Secrets, not environment variable literals
-- [ ] Disable debug endpoints in production if not needed (`DISABLE_DEBUG=true`)
 - [ ] Run `make lint` (includes `govulncheck`) before deploying
-- [ ] For high-QPS services: set `RESPONSE_TIME_LOG_ERROR_ONLY=true` to skip per-request logging on successful RPCs (the single largest source of per-request CPU overhead — see [tuning impact](/config-reference#measured-tuning-impact))
+- [ ] For high-QPS services: set `RESPONSE_TIME_LOG_ERROR_ONLY=true` to skip per-request logging on successful RPCs (see [tuning impact](/config-reference#measured-tuning-impact))
+
+### Public-facing services (additional)
+
+- [ ] **Whitelist public API paths** at the load balancer — block `/debug/*`, `/metrics`, `/swagger/*`
+- [ ] `DISABLE_DEBUG=true` — disable pprof endpoints
+- [ ] `DISABLE_SWAGGER=true` — disable API documentation
+- [ ] `DISABLE_GRPC_REFLECTION=true` — disable service discovery
+- [ ] `DISABLE_DEBUG_LOG_INTERCEPTOR=true` — disable header-based debug logging
+- [ ] Consider reducing `GRPC_MAX_SEND_MSG_SIZE` from its ~2GB default if responses are small
+- [ ] Restrict `/metrics` access at the load balancer
+- [ ] `LOG_LEVEL=info` or higher (never `debug`)
 
 ---
 [ColdBrew cookiecutter]: /getting-started

--- a/howto/signals.md
+++ b/howto/signals.md
@@ -41,8 +41,8 @@ When the application receives a signal, ColdBrew executes a multi-step shutdown 
 
 Configuring the shutdown process is done by setting the [config] values:
 
-- `SHUTDOWN_DURATION_IN_SECONDS` - Total shutdown timeout (default: 15s). After this, the process exits regardless.
-- `GRPC_GRACEFUL_DURATION_IN_SECONDS` - How long to wait after failing `/readycheck` before stopping servers (default: 7s). This gives the load balancer time to drain.
+- `SHUTDOWN_DURATION_IN_SECONDS` - Timeout for the entire `Stop()` sequence (default: 15s), covering steps 2-7 above including the drain wait. After this, the process exits regardless.
+- `GRPC_GRACEFUL_DURATION_IN_SECONDS` - Duration of step 2 — how long to wait after failing `/readycheck` before stopping servers (default: 7s). This is **included within** `SHUTDOWN_DURATION_IN_SECONDS`, not additional to it.
 - `DISABLE_SIGNAL_HANDLER` - If set to `true`, ColdBrew will not register a signal handler (useful when you want to handle signals yourself).
 
 ## Service lifecycle interfaces

--- a/howto/signals.md
+++ b/howto/signals.md
@@ -27,26 +27,50 @@ When you start your application, ColdBrew will register a signal handler for `SI
 
 ## Graceful shutdown
 
-When the application receives a signal, it will start a graceful shutdown process. This process will do the following:
+When the application receives a signal, ColdBrew executes a multi-step shutdown sequence:
 
-  1. Fail the readiness check
-  2. Wait for all requests to finish
-  3. Shutdown the application when all requests are finished or after a timeout
+1. **`FailCheck(true)`** on services implementing [CBGracefulStopper] — `/readycheck` starts returning failure
+2. **Wait** `GRPC_GRACEFUL_DURATION_IN_SECONDS` (default: 7s) for the load balancer to stop sending traffic
+3. **Shutdown HTTP server** — stop accepting new HTTP requests
+4. **`GracefulStop()` gRPC server** — finish in-flight RPCs, reject new ones
+5. **Force-stop gRPC server** if graceful shutdown didn't complete in time
+6. **`Stop()`** on services implementing [CBStopper] — resource cleanup
+7. **Exit**
 
 ## Customizing the shutdown process
 
 Configuring the shutdown process is done by setting the [config] values:
 
-- `SHUTDOWN_DURATION_IN_SECONDS` - The duration in seconds to wait for all requests to finish before shutting down the application.
-- `GRPC_GRACEFUL_DURATION_IN_SECONDS` - The duration in seconds for which ColdBrew will wait for propagation of readiness check failure to the load balancer.
-- `DISABLE_SIGNAL_HANDLER` - If set to `true`, ColdBrew will not register a signal handler (this is useful when you want to handle signals yourself).
+- `SHUTDOWN_DURATION_IN_SECONDS` - Total shutdown timeout (default: 15s). After this, the process exits regardless.
+- `GRPC_GRACEFUL_DURATION_IN_SECONDS` - How long to wait after failing `/readycheck` before stopping servers (default: 7s). This gives the load balancer time to drain.
+- `DISABLE_SIGNAL_HANDLER` - If set to `true`, ColdBrew will not register a signal handler (useful when you want to handle signals yourself).
+
+## Service lifecycle interfaces
+
+ColdBrew provides two optional interfaces for shutdown behavior:
+
+| Interface | Method | When called | Use for |
+|-----------|--------|-------------|---------|
+| [CBGracefulStopper] | `FailCheck(bool)` | **First** — before drain wait | Mark service as not ready |
+| [CBStopper] | `Stop()` | **Last** — after all servers stopped | Close DB pools, flush metrics, drain producers |
+
+{: .important}
+All resource cleanup belongs in `Stop()`. ColdBrew calls it after all servers have stopped and in-flight requests have completed (or timed out).
 
 ## Cleanup before shutdown
 
-If your service implements [CBStopper] interface, ColdBrew will call the `Stop` method when the application is shutting down. This is useful if you want to perform some cleanup before the application shuts down.
+Implement the [CBStopper] interface to clean up resources during shutdown:
 
-{: .important}
-ColdBrew will call the `Stop` method after all requests have finished or after the `SHUTDOWN_DURATION_IN_SECONDS` timeout has expired.
+```go
+func (s *svc) Stop() {
+    s.dbPool.Close()           // close database connections
+    s.redisClient.Close()      // close Redis
+    s.metricsReporter.Flush()  // flush pending metrics
+    s.kafkaProducer.Close()    // drain and close Kafka producer
+}
+```
+
+The [ColdBrew cookiecutter] generates this pattern — your service struct implements `CBStopper` and delegates to the service implementation's `Stop()` method.
 
 ## Kubernetes liveness and readiness probes
 
@@ -65,5 +89,6 @@ Make sure you configure your load balancer to stop sending new requests to your 
 [go-coldbrew/core]: https://pkg.go.dev/github.com/go-coldbrew/core
 [config]: https://pkg.go.dev/github.com/go-coldbrew/core/config#Config
 [CBStopper]: https://pkg.go.dev/github.com/go-coldbrew/core#CBStopper
+[CBGracefulStopper]: https://pkg.go.dev/github.com/go-coldbrew/core#CBGracefulStopper
 [Kubernetes]: https://kubernetes.io/
 [POSIX signals]: https://en.wikipedia.org/wiki/Signal_(IPC)#POSIX_signals


### PR DESCRIPTION
## Summary
- Add "Security hardening" section to production.md with:
  - Disclaimer: follow your org's security policies
  - **Path whitelisting** as the core recommendation for public-facing services
  - Public-facing service env config (disable debug, swagger, reflection, debug log interceptor)
  - Internal service guidance (what can stay enabled)
  - Built-in protections table (trace ID validation, protovalidate, default timeout, panic recovery)
  - Data sent to third-party services (Sentry, NR, Rollbar) — what gets sent and PII warning
  - Not built into ColdBrew (CORS, auth, rate limiting, header forwarding)
- Expand production checklist: split into "All services" and "Public-facing services (additional)"
- Clarify send/recv msg size descriptions in config-reference.md (response vs request)

## Test plan
- [x] All referenced config vars verified against `core/config/config.go`
- [x] All referenced features verified against actual code
- [x] No broken links — all anchors reference existing pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced per-request debug logging documentation with trace ID correlation across services.
  * Clarified gRPC message size limit configurations and streaming guidance for large payloads.
  * Detailed graceful shutdown process with service lifecycle interfaces and sequence.
  * Added security hardening guidance for public-facing services with configuration controls.
  * Documented new configuration options for managing debug logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->