### PR TITLE
docs: document stdlib re-exports in errors package

### DIFF
--- a/Packages.md
+++ b/Packages.md
@@ -35,7 +35,7 @@ Interceptors provides a common set of reusable interceptors for grpc services
 Documentation can be found at [interceptor-docs]
 
 ## [Errors]
-errors provides an implementation of golang error with stack strace information attached to it, the error objects created by this package are compatible with https://golang.org/pkg/errors/
+A drop-in replacement for the standard `errors` package that adds stack trace capture, gRPC status codes, and error notification support. All standard library functions (`Is`, `As`, `Unwrap`, `Join`) are re-exported.
 
 Documentation can be found at [errors-docs]
 

--- a/Packages.md
+++ b/Packages.md
@@ -35,7 +35,7 @@ Interceptors provides a common set of reusable interceptors for grpc services
 Documentation can be found at [interceptor-docs]
 
 ## [Errors]
-A drop-in replacement for the standard `errors` package that adds stack trace capture, gRPC status codes, and error notification support. All standard library functions (`Is`, `As`, `Unwrap`, `Join`) are re-exported.
+A drop-in replacement for the standard `errors` package that adds stack trace capture and gRPC status codes. Standard library helpers (`Is`, `As`, `Unwrap`, `Join`) are re-exported. Error notification is provided by the [Notifier] sub-package below.
 
 Documentation can be found at [errors-docs]
 

--- a/howto/errors.md
+++ b/howto/errors.md
@@ -59,7 +59,6 @@ func somefunction() error {
 The ColdBrew [errors package] provides a `Wrap` function that can be used to wrap an error with a message. This is useful when you want to add more context to an error.
 
 ```go
-
 import (
     "github.com/go-coldbrew/errors"
 )
@@ -74,6 +73,63 @@ func function2() error {
     err := function1()
     return errors.Wrap(err, "some context")
 }
+```
+
+### Checking errors
+
+All standard library error functions are re-exported, so you don't need a separate `import "errors"`. Use `errors.Is` to check if an error matches a sentinel value, and `errors.As` to extract a specific error type from the chain:
+
+```go
+import (
+    "github.com/go-coldbrew/errors"
+)
+
+// Check if an error matches a sentinel value
+if errors.Is(err, sql.ErrNoRows) {
+    // handle not found
+}
+
+// Extract a specific error type from the chain
+var ext errors.ErrorExt
+if errors.As(err, &ext) {
+    fmt.Println("gRPC code:", ext.GRPCStatus().Code())
+}
+```
+
+### Finding root cause
+
+Use `errors.Cause` to walk the `Unwrap` chain and find the root cause error. This works on any error, not just ColdBrew errors:
+
+```go
+root := errors.Cause(err)
+fmt.Println("root cause:", root)
+```
+
+For ColdBrew errors, you can also use the `Cause()` method on the `ErrorExt` interface, which returns the same result.
+
+### Combining errors
+
+Use `errors.Join` to combine multiple errors into a single error:
+
+```go
+err1 := errors.New("first problem")
+err2 := errors.New("second problem")
+combined := errors.Join(err1, err2)
+
+// Both errors are preserved in the chain
+errors.Is(combined, err1) // true
+errors.Is(combined, err2) // true
+```
+
+### Unwrapping errors
+
+Use `errors.Unwrap` to get the immediate parent error in the chain:
+
+```go
+base := errors.New("base")
+wrapped := errors.Wrap(base, "context")
+
+inner := errors.Unwrap(wrapped) // returns base
 ```
 
 ## ColdBrew notifier package

--- a/howto/errors.md
+++ b/howto/errors.md
@@ -81,6 +81,9 @@ All standard library error functions are re-exported, so you don't need a separa
 
 ```go
 import (
+    "database/sql"
+    "fmt"
+
     "github.com/go-coldbrew/errors"
 )
 

--- a/howto/errors.md
+++ b/howto/errors.md
@@ -77,7 +77,7 @@ func function2() error {
 
 ### Checking errors
 
-All standard library error functions are re-exported, so you don't need a separate `import "errors"`. Use `errors.Is` to check if an error matches a sentinel value, and `errors.As` to extract a specific error type from the chain:
+Standard library error helpers (`Is`, `As`, `Unwrap`, `Join`) are re-exported, so you don't need a separate `import "errors"`. Use `errors.Is` to check if an error matches a sentinel value, and `errors.As` to extract a specific error type from the chain:
 
 ```go
 import (
@@ -87,25 +87,26 @@ import (
     "github.com/go-coldbrew/errors"
 )
 
-// Check if an error matches a sentinel value
-if errors.Is(err, sql.ErrNoRows) {
-    // handle not found
-}
+func handleQuery(err error) {
+    // Check if an error matches a sentinel value
+    if errors.Is(err, sql.ErrNoRows) {
+        // handle not found
+    }
 
-// Extract a specific error type from the chain
-var ext errors.ErrorExt
-if errors.As(err, &ext) {
-    fmt.Println("gRPC code:", ext.GRPCStatus().Code())
+    // Extract a specific error type from the chain
+    var ext errors.ErrorExt
+    if errors.As(err, &ext) {
+        fmt.Println("gRPC code:", ext.GRPCStatus().Code())
+    }
 }
 ```
 
 ### Finding root cause
 
-Use `errors.Cause` to walk the `Unwrap` chain and find the root cause error. This works on any error, not just ColdBrew errors:
+ColdBrew also provides `errors.Cause` to walk the `Unwrap` chain and find the root cause error. This works on any error, not just ColdBrew errors:
 
 ```go
-root := errors.Cause(err)
-fmt.Println("root cause:", root)
+root := errors.Cause(err) // returns the innermost error in the chain
 ```
 
 For ColdBrew errors, you can also use the `Cause()` method on the `ErrorExt` interface, which returns the same result.


### PR DESCRIPTION
## Summary

- Add new sections to the errors howto page covering `Is`, `As`, `Unwrap`, `Join`, and `Cause` — now that go-coldbrew/errors#30 re-exports all stdlib error functions
- Update the Packages page description to reflect the drop-in replacement capability

## Test plan

- [ ] Verify CI / Playwright tests pass (no page paths or nav structure changed, content-only update)
- [ ] Visual review of rendered howto/errors page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Errors package docs to describe current behavior: drop-in compatibility with Go standard errors, automatic stack-trace capture, gRPC status integration, re-exported standard helper functions, and error notification support.
  * Added user-facing error-handling guides with examples for checking errors, finding root causes, combining multiple errors, and unwrapping errors for diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->