### PR TITLE
docs: document TLS certificate auto-reload feature

### DIFF
--- a/Index.md
+++ b/Index.md
@@ -33,6 +33,7 @@ A Kubernetes-native Go microservice framework for building production-grade gRPC
 | **Rate Limiting** | Per-pod token bucket rate limiter — disabled by default, pluggable via custom [`ratelimit.Limiter`](https://pkg.go.dev/github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/ratelimit#Limiter) interface for distributed or per-tenant rate limiting. Config: `RATE_LIMIT_PER_SECOND`. See [interceptors howto](/howto/interceptors#rate-limiting) |
 | **Auth Examples** | JWT and API key authentication interceptor examples in the [cookiecutter template][ColdBrew cookiecutter], built on [go-grpc-middleware auth](https://github.com/grpc-ecosystem/go-grpc-middleware/tree/main/interceptors/auth). See [auth howto](/howto/auth/) |
 | **Fast Serialization** | [vtprotobuf] codec enabled by default — faster gRPC marshalling with automatic fallback to standard protobuf |
+| **TLS with Auto-Reload** | Automatic certificate hot-reloading via [certinel](https://github.com/cloudflare/certinel) — updated certs are picked up without restart, works with cert-manager and Vault symlink rotation |
 | **Kubernetes-native** | Health/ready probes, graceful SIGTERM shutdown, structured JSON logs, Prometheus metrics — all wired automatically |
 | **Swagger / OpenAPI** | Interactive API docs auto-served at `/swagger/` from your protobuf definitions |
 | **Profiling** | Go [pprof] endpoints at `/debug/pprof/` for CPU, memory, goroutine, and trace profiling |

--- a/Index.md
+++ b/Index.md
@@ -33,7 +33,7 @@ A Kubernetes-native Go microservice framework for building production-grade gRPC
 | **Rate Limiting** | Per-pod token bucket rate limiter — disabled by default, pluggable via custom [`ratelimit.Limiter`](https://pkg.go.dev/github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/ratelimit#Limiter) interface for distributed or per-tenant rate limiting. Config: `RATE_LIMIT_PER_SECOND`. See [interceptors howto](/howto/interceptors#rate-limiting) |
 | **Auth Examples** | JWT and API key authentication interceptor examples in the [cookiecutter template][ColdBrew cookiecutter], built on [go-grpc-middleware auth](https://github.com/grpc-ecosystem/go-grpc-middleware/tree/main/interceptors/auth). See [auth howto](/howto/auth/) |
 | **Fast Serialization** | [vtprotobuf] codec enabled by default — faster gRPC marshalling with automatic fallback to standard protobuf |
-| **TLS with Auto-Reload** | Automatic certificate hot-reloading via [certinel](https://github.com/cloudflare/certinel) — updated certs are picked up without restart, works with cert-manager and Vault symlink rotation |
+| **TLS with Auto-Reload** | Automatic certificate hot-reloading via [certinel](https://github.com/cloudflare/certinel) — updated certs are picked up without a restart; works with cert-manager and Vault symlink rotation |
 | **Kubernetes-native** | Health/ready probes, graceful SIGTERM shutdown, structured JSON logs, Prometheus metrics — all wired automatically |
 | **Swagger / OpenAPI** | Interactive API docs auto-served at `/swagger/` from your protobuf definitions |
 | **Profiling** | Go [pprof] endpoints at `/debug/pprof/` for CPU, memory, goroutine, and trace profiling |

--- a/config-reference.md
+++ b/config-reference.md
@@ -68,6 +68,8 @@ cfg := config.GetColdBrewConfig()
 | `GRPC_TLS_CERT_FILE` | string | `""` | Path to TLS certificate file. Both key and cert must be set to enable TLS |
 | `GRPC_TLS_INSECURE_SKIP_VERIFY` | bool | `false` | Skip TLS certificate verification (development only) |
 
+When TLS is enabled, ColdBrew automatically watches the cert and key files for changes using [certinel](https://github.com/cloudflare/certinel). Updated certificates are picked up without restarting the service — ideal for Kubernetes environments where cert-manager or Vault rotate certificates via symlink swaps.
+
 ## gRPC Keepalive
 
 | Variable | Type | Default | Description |

--- a/howto/production.md
+++ b/howto/production.md
@@ -410,6 +410,8 @@ volumes:
       secretName: myservice-tls
 ```
 
+ColdBrew automatically watches the certificate and key files for changes and reloads them without requiring a restart. This works with cert-manager, Vault Agent, and any other tool that rotates certificates via file or symlink updates.
+
 {: .note }
 If you're using a service mesh that handles mTLS (Istio, Linkerd), you typically don't need ColdBrew's built-in TLS — the mesh sidecar terminates TLS at the pod level.
 


### PR DESCRIPTION
## Summary

- **config-reference.md**: Added note under gRPC TLS table explaining automatic cert watching via certinel
- **howto/production.md**: Added paragraph about auto-reload working with cert-manager and Vault
- **Index.md**: Added "TLS with Auto-Reload" row to the features table

Accompanies go-coldbrew/core#82.

## Test plan

- [ ] Verify pages render correctly on local Jekyll server