### PR TITLE
docs: update workers howto for new features

### DIFF
--- a/howto/workers.md
+++ b/howto/workers.md
@@ -169,6 +169,7 @@ The handler receives a `context.Context` for cancellation and a `*WorkerInfo` fo
 | Return value | Long-running worker (no `Every`) | Periodic worker (with `Every`) |
 |---|---|---|
 | `return nil` | Worker stops permanently | Cycle succeeded — next tick fires |
+| `return workers.ErrSkipTick` | No effect (not meaningful) | Tick skipped — next tick fires normally |
 | `return error` | Restarts with backoff (if restart enabled) | Restarts with backoff (if restart enabled) |
 | `return ctx.Err()` | Clean shutdown | Clean shutdown |
 | `return workers.ErrDoNotRestart` | Permanent stop | Permanent stop |
@@ -176,6 +177,22 @@ The handler receives a `context.Context` for cancellation and a `*WorkerInfo` fo
 **Long-running workers** should block on `<-ctx.Done()`, then return `ctx.Err()`. Returning nil without waiting for ctx cancellation stops the worker permanently.
 
 **Periodic workers** run the handler once per tick. Return nil for success (next tick fires normally). Return an error to trigger restart. The `Every` wrapper manages the tick loop — your handler just processes one cycle.
+
+### ErrSkipTick
+
+Return `workers.ErrSkipTick` from a periodic handler when a tick fails transiently (DB timeout, network blip) and you want to skip it without triggering a full restart. The timer continues and the next tick fires normally:
+
+```go
+func pollDatabase(ctx context.Context, info *workers.WorkerInfo) error {
+    rows, err := db.QueryContext(ctx, "SELECT ...")
+    if err != nil {
+        return workers.ErrSkipTick // skip this tick, try again next interval
+    }
+    return processRows(rows)
+}
+```
+
+Without `ErrSkipTick`, you'd have to swallow errors by returning nil and track them internally. `ErrSkipTick` gives the framework visibility into skipped ticks while keeping the timer going.
 
 ### ErrDoNotRestart
 
@@ -408,6 +425,18 @@ middleware.DistributedLock(redisLocker,
 )
 ```
 
+For the common case of logging and skipping, use `WithSkipOnNotAcquired`:
+
+```go
+middleware.DistributedLock(redisLocker,
+    middleware.WithSkipOnNotAcquired(func(ctx context.Context, name string) {
+        log.Info(ctx, "msg", "lock held, skipping", "worker", name)
+    }),
+)
+```
+
+**Caution:** `WithOnNotAcquired` returns an error. A non-nil return triggers restart for periodic workers. Use `WithSkipOnNotAcquired` or return nil if you want to skip without restart.
+
 The `Locker` interface:
 
 ```go
@@ -416,6 +445,8 @@ type Locker interface {
     Release(ctx context.Context, key string) error
 }
 ```
+
+If your lock implementation already has these two methods with matching signatures, it satisfies `Locker` directly — no adapter needed.
 
 Release uses `context.WithoutCancel` so that context cancellation does not prevent lock cleanup.
 
@@ -468,12 +499,14 @@ Every handler receives a `*WorkerInfo` that carries worker metadata and child ma
 |--------|-------------|
 | `GetName() string` | Worker name |
 | `GetAttempt() int` | Restart attempt (0 on first run) |
+| `GetHandler() CycleHandler` | The worker's handler — use type assertion for handler-specific state |
 | `Add(w *Worker) bool` | Add child worker — returns false if name already exists (no-op) |
 | `Remove(name string)` | Stop child worker by name |
-| `GetChildren() []string` | Names of running child workers |
+| `GetChildren() []string` | Names of running child workers (stopped children auto-pruned) |
 | `GetChild(name string) (Worker, bool)` | Look up a child by name (returns a value copy) |
+| `GetChildCount() int` | Number of running children (cheaper than `len(GetChildren())`) |
 
-Use `Worker.GetName()` and `Worker.GetHandler()` to inspect a child.
+Use `Worker.GetName()`, `Worker.GetHandler()`, `Worker.GetInterval()`, and `Worker.GetRestartOnFail()` to inspect a child.
 
 To replace a running worker, call `Remove` then `Add`. This is not atomic — there is a brief window where the worker is not running.
 
@@ -578,6 +611,45 @@ info.Add(workers.NewWorker("solver").HandlerFunc(makeSolver(newCfg)))
 ```
 
 Note: `Remove` + `Add` is not atomic — there is a brief window where the worker is not running.
+
+**Automatic cleanup:** When a child permanently stops (returns nil with `WithRestart(false)`, returns `ErrDoNotRestart`, or exhausts restart attempts), it is automatically pruned from the children map on the next call to `GetChildren`, `GetChild`, or `GetChildCount`. No manual cleanup needed.
+
+### Example: Config change detection via handler
+
+Instead of maintaining a parallel map to track per-worker state (e.g., config versions), store metadata on your `CycleHandler` implementation and inspect it via `GetChild().GetHandler()` type assertion:
+
+```go
+type solverHandler struct {
+    version int64
+    cfg     SolverConfig
+}
+
+func (h *solverHandler) RunCycle(ctx context.Context, info *workers.WorkerInfo) error {
+    return solve(ctx, h.cfg)
+}
+
+func (h *solverHandler) Close() error { return nil }
+```
+
+In the reconciler, detect config changes without a parallel tracking map:
+
+```go
+for key, desired := range desiredConfigs {
+    child, exists := info.GetChild(key)
+    if exists {
+        if h, ok := child.GetHandler().(*solverHandler); ok && h.version == desired.version {
+            continue // config unchanged, skip
+        }
+        info.Remove(key) // config changed, replace
+    }
+    info.Add(workers.NewWorker(key).Handler(&solverHandler{
+        version: desired.version,
+        cfg:     desired.cfg,
+    }))
+}
+```
+
+The handler is an interface value — `GetChild()` returns a copy of the `Worker` struct, but the handler reference is shared. Type assertion gives read access to the original handler's fields.
 
 ### Example: Fixed children on startup
 

--- a/howto/workers.md
+++ b/howto/workers.md
@@ -218,7 +218,7 @@ func processQueue(ctx context.Context, info *workers.WorkerInfo) error {
 |--------|-------------|---------|
 | `HandlerFunc(fn)` | Set handler from a plain function | — |
 | `Handler(h)` | Set handler from a `CycleHandler` struct | — |
-| `WithRestart(false)` | Disable restart (one-shot worker) | `true` (restart with backoff) |
+| `WithRestart(false)` | Disable restart (one-shot worker). Periodic workers should generally keep the default; use `ErrSkipTick`/`ErrDoNotRestart` instead. | `true` (restart with backoff) |
 | `Every(duration)` | Run periodically on a fixed interval | — |
 | `WithJitter(percent)` | Randomize tick interval by ±percent (requires `Every`) | inherit run-level |
 | `WithInitialDelay(d)` | Delay first tick (requires `Every`) | — |

--- a/howto/workers.md
+++ b/howto/workers.md
@@ -169,7 +169,7 @@ The handler receives a `context.Context` for cancellation and a `*WorkerInfo` fo
 | Return value | Long-running worker (no `Every`) | Periodic worker (with `Every`) |
 |---|---|---|
 | `return nil` | Worker stops permanently | Cycle succeeded — next tick fires |
-| `return workers.ErrSkipTick` | No effect (not meaningful) | Tick skipped — next tick fires normally |
+| `return workers.ErrSkipTick` | Treated like `return error` (not meaningful) | Tick skipped — next tick fires normally |
 | `return error` | Restarts with backoff (if restart enabled) | Restarts with backoff (if restart enabled) |
 | `return ctx.Err()` | Clean shutdown | Clean shutdown |
 | `return workers.ErrDoNotRestart` | Permanent stop | Permanent stop |
@@ -186,7 +186,10 @@ Return `workers.ErrSkipTick` from a periodic handler when a tick fails transient
 func pollDatabase(ctx context.Context, info *workers.WorkerInfo) error {
     rows, err := db.QueryContext(ctx, "SELECT ...")
     if err != nil {
-        return workers.ErrSkipTick // skip this tick, try again next interval
+        if ctx.Err() != nil {
+            return ctx.Err() // context cancelled — clean shutdown
+        }
+        return workers.ErrSkipTick // transient failure, try again next interval
     }
     defer rows.Close()
     return processRows(rows)

--- a/howto/workers.md
+++ b/howto/workers.md
@@ -505,6 +505,7 @@ Every handler receives a `*WorkerInfo` that carries worker metadata and child ma
 | `Remove(name string)` | Stop child worker by name |
 | `GetChildren() []string` | Names of running child workers (stopped children auto-pruned) |
 | `GetChild(name string) (Worker, bool)` | Look up a child by name (returns a value copy) |
+| `GetChildCount() int` | Number of running children (cheaper than `len(GetChildren())`) |
 
 Use `Worker.GetName()`, `Worker.GetHandler()`, `Worker.GetInterval()`, and `Worker.GetRestartOnFail()` to inspect a child.
 

--- a/howto/workers.md
+++ b/howto/workers.md
@@ -616,7 +616,7 @@ info.Add(workers.NewWorker("solver").HandlerFunc(makeSolver(newCfg)))
 
 Note: `Remove` + `Add` is not atomic — there is a brief window where the worker is not running.
 
-**Automatic cleanup:** When a child permanently stops (see the [return value table](#handler-return-values) for what triggers permanent stop), it is automatically excluded from `GetChildren` and `GetChild`. Suture is the source of truth — no manual cleanup needed. Note that there may be a brief delay between the child stopping and the change being visible, since suture processes stop events asynchronously.
+**Automatic cleanup:** When a child permanently stops (see the [return value table](#handler-return-values) for what triggers permanent stop), it is automatically excluded from `GetChildren` and `GetChild`. The underlying [suture] supervisor is the source of truth — no manual cleanup needed. Note that there may be a brief delay between the child stopping and the change being visible, as stop events are processed asynchronously.
 
 ### Example: Config change detection via handler
 

--- a/howto/workers.md
+++ b/howto/workers.md
@@ -394,7 +394,9 @@ middleware.Recover(func(name string, v any) {
 
 ### Tracing
 
-Creates an OTEL span named `worker:<name>:cycle` for each tick. Records errors on the span:
+Creates an OTEL span named `worker:<name>:cycle` for each tick. Records errors on the span. Worker spans are always sampled regardless of the global sampler — this prevents silent span drops when using `ParentBased(TraceIDRatioBased(...))`, where worker root spans (which have no incoming parent) would otherwise be probabilistically dropped.
+
+The OTEL trace ID is automatically injected into the log context as `trace` for correlation with your tracing backend.
 
 ```go
 middleware.Tracing()

--- a/howto/workers.md
+++ b/howto/workers.md
@@ -188,6 +188,7 @@ func pollDatabase(ctx context.Context, info *workers.WorkerInfo) error {
     if err != nil {
         return workers.ErrSkipTick // skip this tick, try again next interval
     }
+    defer rows.Close()
     return processRows(rows)
 }
 ```
@@ -435,7 +436,7 @@ middleware.DistributedLock(redisLocker,
 )
 ```
 
-**Caution:** `WithOnNotAcquired` returns an error. A non-nil return triggers restart for periodic workers. Use `WithSkipOnNotAcquired` or return nil if you want to skip without restart.
+**Caution:** If the `WithOnNotAcquired` callback returns a non-nil error, the framework treats it as a cycle failure — for periodic workers, this triggers restart with backoff. Use `WithSkipOnNotAcquired` or return nil from the callback if you want to skip without restart.
 
 The `Locker` interface:
 
@@ -504,7 +505,6 @@ Every handler receives a `*WorkerInfo` that carries worker metadata and child ma
 | `Remove(name string)` | Stop child worker by name |
 | `GetChildren() []string` | Names of running child workers (stopped children auto-pruned) |
 | `GetChild(name string) (Worker, bool)` | Look up a child by name (returns a value copy) |
-| `GetChildCount() int` | Number of running children (cheaper than `len(GetChildren())`) |
 
 Use `Worker.GetName()`, `Worker.GetHandler()`, `Worker.GetInterval()`, and `Worker.GetRestartOnFail()` to inspect a child.
 
@@ -612,7 +612,7 @@ info.Add(workers.NewWorker("solver").HandlerFunc(makeSolver(newCfg)))
 
 Note: `Remove` + `Add` is not atomic — there is a brief window where the worker is not running.
 
-**Automatic cleanup:** When a child permanently stops (returns nil with `WithRestart(false)`, returns `ErrDoNotRestart`, or exhausts restart attempts), it is automatically pruned from the children map on the next call to `GetChildren`, `GetChild`, or `GetChildCount`. No manual cleanup needed.
+**Automatic cleanup:** When a child permanently stops (see the [return value table](#handler-return-values) for what triggers permanent stop), it is automatically excluded from `GetChildren` and `GetChild`. Suture is the source of truth — no manual cleanup needed. Note that there may be a brief delay between the child stopping and the change being visible, since suture processes stop events asynchronously.
 
 ### Example: Config change detection via handler
 
@@ -649,7 +649,7 @@ for key, desired := range desiredConfigs {
 }
 ```
 
-The handler is an interface value — `GetChild()` returns a copy of the `Worker` struct, but the handler reference is shared. Type assertion gives read access to the original handler's fields.
+`GetChild()` returns a copy of the `Worker` struct, but the handler is stored as a `CycleHandler` interface — use type assertion to access handler-specific fields for change detection or metadata inspection.
 
 ### Example: Fixed children on startup
 


### PR DESCRIPTION
## Summary

- Add `ErrSkipTick` to handler return values table with usage example
- Document automatic zombie child cleanup in Dynamic Workers section
- Add handler-as-metadata reconciler example (config change detection via `GetChild().GetHandler()` type assertion)
- Add `WithSkipOnNotAcquired` convenience + footgun warning for `WithOnNotAcquired` error return
- Update WorkerInfo methods table with `GetHandler`, `GetChildCount`
- Note `Locker` interface compatibility for existing implementations

Companion to go-coldbrew/workers#6.

## Test plan

- [x] Playwright tests pass (navigation + search)
- [x] Workers howto page loads correctly