### PR TITLE
docs: readiness patterns and workers ColdBrew integration

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -241,7 +241,7 @@ Define streaming RPCs in your `.proto` file as usual:
 rpc StreamEvents(EventRequest) returns (stream Event) {}
 ```
 
-Note: grpc-gateway v2 does support streaming RPCs over HTTP by translating them to newline-delimited JSON streams. However, practical constraints apply: reverse proxies may buffer responses (requiring `X-Accel-Buffering: no` or equivalent), error handling uses `runtime.WithStreamErrorHandler`, and true concurrent bidirectional interleaving (like WebSockets) is limited over HTTP/1.1. For high-frequency real-time push, consider a dedicated WebSocket or SSE endpoint alongside the gateway. See the [grpc-gateway streaming examples](https://github.com/grpc-ecosystem/grpc-gateway/tree/main/examples/internal/proto/examplepb) for implementation guidance.
+Note: grpc-gateway v2 supports **server streaming** over HTTP by translating gRPC server streams to newline-delimited JSON. Client streaming and bidirectional streaming have limited support — they translate to HTTP but lack true concurrent interleaving over HTTP/1.1. Practical constraints: reverse proxies may buffer streamed responses (requiring `X-Accel-Buffering: no`), and errors in streams are handled via `runtime.WithStreamErrorHandler`. For high-frequency real-time push or bidirectional communication, consider a dedicated WebSocket or SSE endpoint alongside the gateway. See the [grpc-gateway streaming examples](https://github.com/grpc-ecosystem/grpc-gateway/tree/main/examples/internal/proto/examplepb) for details.
 
 ## How do I run background workers in my service?
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -231,6 +231,40 @@ This routes the gateway's internal connection through a Unix socket instead of T
 
 Use `RegisterHandlerServer` instead of `RegisterHandlerFromEndpoint` in your `InitHTTP`, and wrap each gRPC method with `interceptors.DoHTTPtoGRPC()`. This eliminates all network overhead (~19µs) while preserving the full interceptor chain. Requires per-method wrappers — see the [Architecture page](/architecture#gateway-performance-options) for a code example.
 
+## Can I use ColdBrew with gRPC streaming?
+
+Yes. ColdBrew supports both **server streaming** and **bidirectional streaming** RPCs. The stream interceptor chain (response time logging, protovalidate, metrics, panic recovery) is applied automatically.
+
+Define streaming RPCs in your `.proto` file as usual:
+
+```protobuf
+rpc StreamEvents(EventRequest) returns (stream Event) {}
+```
+
+Note: the HTTP/JSON gateway (grpc-gateway) does not support streaming — streaming RPCs are gRPC-only. HTTP clients should use Server-Sent Events or WebSockets as a separate endpoint if real-time push is needed.
+
+## How do I run background workers in my service?
+
+Implement the `CBWorkerProvider` optional interface on your service:
+
+```go
+func (s *svc) Workers() []*workers.Worker {
+    return []*workers.Worker{
+        workers.NewWorker("cleanup").HandlerFunc(s.cleanup).Every(5 * time.Minute),
+    }
+}
+```
+
+ColdBrew discovers this at startup and manages workers alongside gRPC/HTTP servers — with automatic panic recovery, configurable restart, and graceful shutdown. See the [Workers How-To](/howto/workers) for middleware, jitter, dynamic children, and the [Readiness Patterns](/howto/readiness) guide for integrating workers with health checks.
+
+## Why is my HTTP gateway slow?
+
+Two common causes and their fixes:
+
+1. **TCP loopback overhead** — The gateway connects to gRPC via TCP by default. Set `DISABLE_UNIX_GATEWAY=false` to use a Unix socket instead (~1.9x faster). See [gateway performance options](/architecture#gateway-performance-options).
+
+2. **Protobuf serialization** — Standard `proto.Marshal` uses reflection. Ensure your proto generation includes vtprotobuf (`vtproto` plugin in `buf.gen.yaml`). ColdBrew's codec uses VT methods automatically when available. See the [vtprotobuf How-To](/howto/vtproto).
+
 ## Where can I get help?
 
 - **[GitHub Discussions](https://github.com/go-coldbrew/core/discussions)** — Ask questions, share ideas

--- a/FAQ.md
+++ b/FAQ.md
@@ -241,7 +241,7 @@ Define streaming RPCs in your `.proto` file as usual:
 rpc StreamEvents(EventRequest) returns (stream Event) {}
 ```
 
-Note: the HTTP/JSON gateway (grpc-gateway) does not support streaming — streaming RPCs are gRPC-only. HTTP clients should use Server-Sent Events or WebSockets as a separate endpoint if real-time push is needed.
+Note: grpc-gateway v2 does support streaming RPCs over HTTP by translating them to newline-delimited JSON streams. However, practical constraints apply: reverse proxies may buffer responses (requiring `X-Accel-Buffering: no` or equivalent), error handling uses `runtime.WithStreamErrorHandler`, and true concurrent bidirectional interleaving (like WebSockets) is limited over HTTP/1.1. For high-frequency real-time push, consider a dedicated WebSocket or SSE endpoint alongside the gateway. See the [grpc-gateway streaming examples](https://github.com/grpc-ecosystem/grpc-gateway/tree/main/examples/internal/proto/examplepb) for implementation guidance.
 
 ## How do I run background workers in my service?
 

--- a/howto/APIs.md
+++ b/howto/APIs.md
@@ -767,6 +767,13 @@ Benchmark source: [`benchmarks/`](https://github.com/go-coldbrew/core/tree/main/
 [errors package]: https://pkg.go.dev/github.com/go-coldbrew/errors
 [envconfig]: https://github.com/kelseyhightower/envconfig
 [ColdBrew]: https://docs.coldbrew.cloud
+## Related
+
+- [Swagger](/howto/swagger) — serve OpenAPI/Swagger UI for your endpoints
+- [Errors](/howto/errors) — gRPC status codes, stack traces, error notification
+- [vtprotobuf](/howto/vtproto) — optimize protobuf serialization for high throughput
+- [Testing](/howto/testing) — unit tests and benchmarks for your endpoints
+
 [google.api.http annotations]: https://cloud.google.com/endpoints/docs/grpc/transcoding
 [grpc-gateway]: https://grpc-ecosystem.github.io/grpc-gateway/
 [gRPC Gateway mapping]: https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/examples/

--- a/howto/auth.md
+++ b/howto/auth.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Authentication"
 parent: "How To"
-nav_order: 18
+nav_order: 19
 description: "Adding JWT and API key authentication to ColdBrew gRPC services using go-grpc-middleware auth interceptors"
 ---
 ## Table of contents

--- a/howto/index.md
+++ b/howto/index.md
@@ -9,7 +9,29 @@ has_toc: true
 ---
 # How To
 
-This section contains a collection of how-to guides for ColdBrew.
+Step-by-step guides for building, running, and operating ColdBrew services.
+
+| I want to... | Read |
+|---|---|
+| Define gRPC + HTTP endpoints | [APIs](/howto/APIs) |
+| Set up gRPC connection pooling | [gRPC](/howto/gRPC) |
+| Add structured logging | [Log](/howto/Log) |
+| Handle errors with stack traces | [Errors](/howto/errors) |
+| Add distributed tracing | [Tracing](/howto/Tracing) |
+| Expose Prometheus metrics | [Metrics](/howto/Metrics) |
+| Customize the interceptor chain | [Interceptors](/howto/interceptors) |
+| Debug requests in production | [Debugging](/howto/Debugging) |
+| Handle graceful shutdown | [Signals](/howto/signals) |
+| Serve Swagger/OpenAPI UI | [Swagger](/howto/swagger) |
+| Use dependency injection | [Data Builder](/howto/data-builder) |
+| Optimize protobuf serialization | [vtprotobuf](/howto/vtproto) |
+| Deploy to Kubernetes | [Production](/howto/production) |
+| Write tests and benchmarks | [Testing](/howto/testing) |
+| Run background workers | [Workers](/howto/workers) |
+| Use private Go modules | [Private Modules](/howto/private-modules) |
+| Manage readiness with workers | [Readiness Patterns](/howto/readiness) |
+| Set up local dev with Docker | [Local Development](/howto/local-dev) |
+| Add JWT / API key auth | [Authentication](/howto/auth) |
 
 If you have a How To that you would like to share, please [open an issue](https://github.com/go-coldbrew/docs.coldbrew.cloud/issues)
 

--- a/howto/interceptors.md
+++ b/howto/interceptors.md
@@ -275,8 +275,6 @@ Use the function [AddUnaryServerInterceptor] and [AddUnaryClientInterceptor] to 
 
 ---
 
-[TraceId interceptor]: https://pkg.go.dev/github.com/go-coldbrew/interceptors#TraceIdInterceptor
-[go-coldbrew/tracing]: https://pkg.go.dev/github.com/go-coldbrew/tracing
 ## Related
 
 - [Production](/howto/production) — rate limiting, TLS, security hardening for deployment
@@ -284,6 +282,8 @@ Use the function [AddUnaryServerInterceptor] and [AddUnaryClientInterceptor] to 
 - [Tracing](/howto/Tracing) — distributed tracing with OpenTelemetry
 - [Architecture](/architecture) — full interceptor chain diagram and request lifecycle
 
+[TraceId interceptor]: https://pkg.go.dev/github.com/go-coldbrew/interceptors#TraceIdInterceptor
+[go-coldbrew/tracing]: https://pkg.go.dev/github.com/go-coldbrew/tracing
 [ColdBrew cookiecutter]: /getting-started
 [interceptors]: https://pkg.go.dev/github.com/go-coldbrew/interceptors
 [UseColdBrewServcerInterceptors]: https://pkg.go.dev/github.com/go-coldbrew/interceptors#UseColdBrewServerInterceptors

--- a/howto/interceptors.md
+++ b/howto/interceptors.md
@@ -277,6 +277,13 @@ Use the function [AddUnaryServerInterceptor] and [AddUnaryClientInterceptor] to 
 
 [TraceId interceptor]: https://pkg.go.dev/github.com/go-coldbrew/interceptors#TraceIdInterceptor
 [go-coldbrew/tracing]: https://pkg.go.dev/github.com/go-coldbrew/tracing
+## Related
+
+- [Production](/howto/production) — rate limiting, TLS, security hardening for deployment
+- [Debugging](/howto/Debugging) — per-request debug logging via DebugLogInterceptor
+- [Tracing](/howto/Tracing) — distributed tracing with OpenTelemetry
+- [Architecture](/architecture) — full interceptor chain diagram and request lifecycle
+
 [ColdBrew cookiecutter]: /getting-started
 [interceptors]: https://pkg.go.dev/github.com/go-coldbrew/interceptors
 [UseColdBrewServcerInterceptors]: https://pkg.go.dev/github.com/go-coldbrew/interceptors#UseColdBrewServerInterceptors

--- a/howto/local-dev.md
+++ b/howto/local-dev.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Local Development"
 parent: "How To"
-nav_order: 17
+nav_order: 18
 description: "Docker Compose local dev stack with per-service profiles for databases, caches, message brokers, AWS/GCP emulators, and observability"
 ---
 ## Table of contents

--- a/howto/production.md
+++ b/howto/production.md
@@ -624,4 +624,12 @@ These are your responsibility to handle at the infrastructure level:
 - [ ] `LOG_LEVEL=info` or higher (never `debug`)
 
 ---
+
+## Related
+
+- [Readiness Patterns](/howto/readiness) — health check strategies with workers
+- [Interceptors](/howto/interceptors) — rate limiting, timeout, and custom middleware
+- [Shutdown Lifecycle](/howto/signals) — SIGTERM, drain period, FailCheck sequence
+- [Workers](/howto/workers) — background goroutine management with restart and metrics
+
 [ColdBrew cookiecutter]: /getting-started

--- a/howto/readiness.md
+++ b/howto/readiness.md
@@ -1,0 +1,223 @@
+---
+layout: default
+title: "Readiness Patterns"
+parent: "How To"
+nav_order: 16
+description: "Readiness patterns for ColdBrew services: simple, PreStart-blocked, worker-managed, and dynamic workers with DB-driven config."
+---
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+## Overview
+
+Readiness is a service-level concern. ColdBrew provides the primitives ([CBGracefulStopper], [CBPreStarter], [CBWorkerProvider]) and your service decides when it is ready to accept traffic. Kubernetes readiness probes respect this — traffic is only routed to pods that report `SERVING`.
+
+This page describes four common patterns, from simplest to most advanced.
+
+## Pattern 1: Simple (most services)
+
+Service becomes ready immediately after `InitGRPC`. No workers, no external dependencies to wait for.
+
+```go
+type svc struct {
+    *health.Server
+}
+
+func (s *svc) InitGRPC(ctx context.Context, server *grpc.Server) error {
+    pb.RegisterMyServiceServer(server, s)
+    return nil
+}
+```
+
+In the [cookiecutter template], readiness is managed via `SetReady()` / `SetNotReady()`:
+
+```go
+func New(cfg config.Config) (*svc, error) {
+    s := &svc{Server: GetHealthCheckServer()}
+    SetReady() // service starts accepting traffic
+    return s, nil
+}
+```
+
+Graceful shutdown calls `FailCheck(true)`, which calls `SetNotReady()`. Kubernetes stops routing new requests during the drain period.
+
+**When to use:** Services with no background workers or external dependencies that must be established before serving.
+
+## Pattern 2: Block in PreStart
+
+Use when a dependency (database, message broker, cache) **must** be ready before accepting traffic. [CBPreStarter] blocks server startup until `PreStart` returns.
+
+```go
+var _ core.CBPreStarter = (*cbSvc)(nil)
+
+func (s *cbSvc) PreStart(ctx context.Context) error {
+    // Servers won't start until this returns.
+    // Returning an error aborts startup entirely.
+    db, err := sql.Open("postgres", os.Getenv("DATABASE_URL"))
+    if err != nil {
+        return fmt.Errorf("database connect: %w", err)
+    }
+    if err := db.PingContext(ctx); err != nil {
+        return fmt.Errorf("database ping: %w", err)
+    }
+    s.db = db
+    return nil
+}
+```
+
+`PreStart` runs before `initGRPC` / `initHTTP`, so you can also configure interceptors here:
+
+```go
+func (s *cbSvc) PreStart(ctx context.Context) error {
+    interceptors.SetDefaultTimeout(30 * time.Second)
+    auth.Setup(ctx, config.Get().AuthConfig)
+    return nil
+}
+```
+
+**When to use:** Database connections, message broker connections, mandatory cache warmup, auth interceptor registration. If the dependency fails to connect, the service should not start.
+
+## Pattern 3: Worker-managed readiness
+
+Use when workers can start independently and the service becomes ready once workers report in. Servers start immediately but the health check returns `NOT_SERVING` until all components are ready.
+
+```go
+var (
+    _ core.CBWorkerProvider  = (*cbSvc)(nil)
+    _ core.CBGracefulStopper = (*cbSvc)(nil)
+)
+
+type svc struct {
+    *health.Server
+    kafkaReady atomic.Bool
+    cacheReady atomic.Bool
+}
+
+func (s *svc) Workers() []*workers.Worker {
+    return []*workers.Worker{
+        workers.NewWorker("kafka").HandlerFunc(s.consumeKafka),
+        workers.NewWorker("cache-warmer").
+            HandlerFunc(s.warmCache).
+            Every(5 * time.Minute),
+    }
+}
+
+func (s *svc) consumeKafka(ctx context.Context, info *workers.WorkerInfo) error {
+    consumer, err := kafka.Connect(ctx, s.brokers)
+    if err != nil {
+        return err // triggers worker restart with backoff
+    }
+    s.kafkaReady.Store(true)
+    defer s.kafkaReady.Store(false)
+    return consumer.Consume(ctx)
+}
+
+func (s *svc) warmCache(ctx context.Context, info *workers.WorkerInfo) error {
+    if err := s.cache.WarmAll(ctx); err != nil {
+        return err
+    }
+    s.cacheReady.Store(true)
+    return nil
+}
+```
+
+The health check aggregates readiness from all components:
+
+```go
+func (s *svc) ReadyCheck(ctx context.Context, _ *emptypb.Empty) (*httpbody.HttpBody, error) {
+    if s.kafkaReady.Load() && s.cacheReady.Load() {
+        return readyResponse, nil
+    }
+    return notReadyResponse, ErrNotReady
+}
+```
+
+During graceful shutdown, `FailCheck(true)` forces `NOT_SERVING` regardless of worker state:
+
+```go
+func (s *svc) FailCheck(fail bool) {
+    if fail {
+        s.kafkaReady.Store(false)
+        s.cacheReady.Store(false)
+    }
+}
+```
+
+**When to use:** Services that can start the gRPC/HTTP servers while background workers are still initializing. Kubernetes readiness probes hold traffic until all components report ready.
+
+## Pattern 4: Dynamic workers from DB
+
+Use the manager pattern — one static worker reconciles dynamic children from an external source (database, config service, feature flags).
+
+```go
+func (s *svc) Workers() []*workers.Worker {
+    return []*workers.Worker{
+        workers.NewWorker("reconciler").
+            HandlerFunc(s.reconcileWorkers).
+            Every(30 * time.Second),
+    }
+}
+
+func (s *svc) reconcileWorkers(ctx context.Context, info *workers.WorkerInfo) error {
+    configs, err := s.db.GetWorkerConfigs(ctx)
+    if err != nil {
+        return err
+    }
+
+    // Add new workers from DB
+    for _, cfg := range configs {
+        if info.GetChild(cfg.Name) == nil {
+            info.Add(
+                workers.NewWorker(cfg.Name).
+                    HandlerFunc(cfg.BuildHandler(s.deps)).
+                    Every(cfg.Interval).
+                    WithJitter(10),
+            )
+        }
+    }
+
+    // Remove workers no longer in DB
+    for _, name := range info.GetChildren() {
+        if !existsInConfigs(name, configs) {
+            info.Remove(name)
+        }
+    }
+    return nil
+}
+```
+
+When the reconciler stops (parent shutdown), all dynamic children stop automatically — scoped lifecycle via the [suture] supervisor tree.
+
+For readiness, combine with Pattern 3: the reconciler sets a ready flag after the first successful reconciliation.
+
+**When to use:** Multi-tenant workers, feature-flagged background jobs, queue-per-customer patterns. See [Dynamic Workers] in the workers howto for the full API.
+
+## Choosing a Pattern
+
+| Pattern | Blocks startup? | Workers? | Complexity |
+|---------|----------------|----------|------------|
+| **Simple** | No | No | Trivial |
+| **PreStart** | Yes | Optional | Low |
+| **Worker-managed** | No | Yes | Medium |
+| **Dynamic** | No | Yes (dynamic) | Higher |
+
+Most services start with Pattern 1 or 2. Add Pattern 3 when you introduce background workers that affect readiness. Pattern 4 is for advanced multi-tenant or config-driven scenarios.
+
+## Related
+
+- [Workers] — full workers howto (middleware, jitter, dynamic children, metrics)
+- [Shutdown Lifecycle] — how ColdBrew handles SIGTERM, FailCheck, drain period
+- [Production Checklist] — readiness probes, resource limits, HPA configuration
+
+[CBGracefulStopper]: https://pkg.go.dev/github.com/go-coldbrew/core#CBGracefulStopper
+[CBPreStarter]: https://pkg.go.dev/github.com/go-coldbrew/core#CBPreStarter
+[CBWorkerProvider]: https://pkg.go.dev/github.com/go-coldbrew/core#CBWorkerProvider
+[cookiecutter template]: /cookiecutter-reference
+[Workers]: /howto/workers
+[Dynamic Workers]: /howto/workers#dynamic-workers
+[Shutdown Lifecycle]: /howto/signals
+[Production Checklist]: /howto/production
+[suture]: https://github.com/thejerf/suture

--- a/howto/readiness.md
+++ b/howto/readiness.md
@@ -68,15 +68,17 @@ func (s *cbSvc) PreStart(ctx context.Context) error {
 }
 ```
 
-`PreStart` runs before `initGRPC` / `initHTTP`, so you can also configure interceptors here:
+`PreStart` runs before `initGRPC` / `initHTTP`, so you can also register auth interceptors or other setup here:
 
 ```go
 func (s *cbSvc) PreStart(ctx context.Context) error {
-    interceptors.SetDefaultTimeout(30 * time.Second)
     auth.Setup(ctx, config.Get().AuthConfig)
     return nil
 }
 ```
+
+{: .note }
+For configuration that has an environment variable equivalent (like `GRPC_SERVER_DEFAULT_TIMEOUT_IN_SECONDS`), prefer the env var via the [Configuration Reference](/config-reference). Use `PreStart` for setup that requires code — auth interceptors, database connections, programmatic interceptor configuration via `interceptors.Set*()` functions.
 
 **When to use:** Database connections, message broker connections, mandatory cache warmup, auth interceptor registration. If the dependency fails to connect, the service should not start.
 
@@ -86,8 +88,8 @@ Use when workers can start independently and the service becomes ready once work
 
 ```go
 var (
-    _ core.CBWorkerProvider  = (*cbSvc)(nil)
-    _ core.CBGracefulStopper = (*cbSvc)(nil)
+    _ core.CBWorkerProvider  = (*svc)(nil)
+    _ core.CBGracefulStopper = (*svc)(nil)
 )
 
 type svc struct {
@@ -169,7 +171,7 @@ func (s *svc) reconcileWorkers(ctx context.Context, info *workers.WorkerInfo) er
 
     // Add new workers from DB
     for _, cfg := range configs {
-        if info.GetChild(cfg.Name) == nil {
+        if _, exists := info.GetChild(cfg.Name); !exists {
             info.Add(
                 workers.NewWorker(cfg.Name).
                     HandlerFunc(cfg.BuildHandler(s.deps)).

--- a/howto/readiness.md
+++ b/howto/readiness.md
@@ -19,7 +19,7 @@ This page describes four common patterns, from simplest to most advanced.
 
 ## Pattern 1: Simple (most services)
 
-Service becomes ready immediately after `InitGRPC`. No workers, no external dependencies to wait for.
+Service becomes ready during initialization. No workers, no external dependencies to wait for.
 
 ```go
 type svc struct {

--- a/howto/readiness.md
+++ b/howto/readiness.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Readiness Patterns"
 parent: "How To"
-nav_order: 16
+nav_order: 17
 description: "Readiness patterns for ColdBrew services: simple, PreStart-blocked, worker-managed, and dynamic workers with DB-driven config."
 ---
 ## Table of contents

--- a/howto/readiness.md
+++ b/howto/readiness.md
@@ -61,6 +61,7 @@ func (s *cbSvc) PreStart(ctx context.Context) error {
         return fmt.Errorf("database connect: %w", err)
     }
     if err := db.PingContext(ctx); err != nil {
+        db.Close()
         return fmt.Errorf("database ping: %w", err)
     }
     s.db = db

--- a/howto/signals.md
+++ b/howto/signals.md
@@ -45,8 +45,8 @@ When the application receives a signal, ColdBrew executes a multi-step shutdown 
 
 Configuring the shutdown process is done by setting the [config] values:
 
-- `SHUTDOWN_DURATION_IN_SECONDS` - Timeout for the entire `Stop()` sequence (default: 15s), covering steps 1-8 above including the drain wait. After this, the process exits regardless.
-- `GRPC_GRACEFUL_DURATION_IN_SECONDS` - Duration of step 2 — how long to wait after failing `/readycheck` before stopping servers (default: 7s). This is **included within** `SHUTDOWN_DURATION_IN_SECONDS`, not additional to it.
+- `SHUTDOWN_DURATION_IN_SECONDS` - Timeout for the entire `Stop()` sequence (default: 15s), covering steps 1-11 above including the drain wait. After this, the process exits regardless.
+- `GRPC_GRACEFUL_DURATION_IN_SECONDS` - Duration of step 3 — how long to wait after failing `/readycheck` before stopping servers (default: 7s). This is **included within** `SHUTDOWN_DURATION_IN_SECONDS`, not additional to it.
 - `DISABLE_SIGNAL_HANDLER` - If set to `true`, ColdBrew will not register a signal handler (useful when you want to handle signals yourself).
 
 ## Service lifecycle interfaces
@@ -61,7 +61,7 @@ ColdBrew provides optional interfaces for lifecycle hooks:
 | [CBPostStopper] | `PostStop(ctx)` | After Stop, before exit | Final cleanup, audit log close |
 
 {: .important}
-All resource cleanup belongs in `Stop()`. ColdBrew calls it after all servers have stopped and in-flight requests have completed (or timed out).
+Heavy resource cleanup (closing DB pools, flushing metrics) belongs in `Stop()`. Use `PreStop` for pre-shutdown actions like deregistering from service discovery, and `PostStop` for final cleanup after everything has stopped.
 
 ## Cleanup before shutdown
 

--- a/howto/signals.md
+++ b/howto/signals.md
@@ -29,14 +29,17 @@ When you start your application, ColdBrew will register a signal handler for `SI
 
 When the application receives a signal, ColdBrew executes a multi-step shutdown sequence:
 
-1. **`FailCheck(true)`** on services implementing [CBGracefulStopper] — `/readycheck` starts returning failure
-2. **Wait** `GRPC_GRACEFUL_DURATION_IN_SECONDS` (default: 7s) for the load balancer to stop sending traffic
-3. **Shutdown admin server** if configured (`ADMIN_PORT`)
-4. **Shutdown HTTP server** — stop accepting new HTTP requests
-5. **`GracefulStop()` gRPC server** — finish in-flight RPCs, reject new ones
-6. **Force-stop gRPC server** if graceful shutdown didn't complete in time
-7. **`Stop()`** on services implementing [CBStopper] — resource cleanup
-8. **Exit**
+1. **`PreStop(ctx)`** on services implementing [CBPreStopper] — deregister from service discovery, flush buffers
+2. **`FailCheck(true)`** on services implementing [CBGracefulStopper] — `/readycheck` starts returning failure
+3. **Wait** `GRPC_GRACEFUL_DURATION_IN_SECONDS` (default: 7s) for the load balancer to stop sending traffic
+4. **Stop workers** — cancel worker context, wait for workers to exit
+5. **Shutdown admin server** if configured (`ADMIN_PORT`)
+6. **Shutdown HTTP server** — stop accepting new HTTP requests
+7. **`GracefulStop()` gRPC server** — finish in-flight RPCs, reject new ones
+8. **Force-stop gRPC server** if graceful shutdown didn't complete in time
+9. **`Stop()`** on services implementing [CBStopper] — resource cleanup
+10. **`PostStop(ctx)`** on services implementing [CBPostStopper] — final cleanup after everything stopped
+11. **Exit**
 
 ## Customizing the shutdown process
 
@@ -48,12 +51,14 @@ Configuring the shutdown process is done by setting the [config] values:
 
 ## Service lifecycle interfaces
 
-ColdBrew provides two optional interfaces for shutdown behavior:
+ColdBrew provides optional interfaces for lifecycle hooks:
 
 | Interface | Method | When called | Use for |
 |-----------|--------|-------------|---------|
-| [CBGracefulStopper] | `FailCheck(bool)` | **First** — before drain wait | Mark service as not ready |
-| [CBStopper] | `Stop()` | **Last** — after all servers stopped | Close DB pools, flush metrics, drain producers |
+| [CBPreStopper] | `PreStop(ctx)` | Before FailCheck | Deregister from service discovery, flush buffers |
+| [CBGracefulStopper] | `FailCheck(bool)` | Before drain wait | Mark service as not ready |
+| [CBStopper] | `Stop()` | After servers stopped | Close DB pools, flush metrics, drain producers |
+| [CBPostStopper] | `PostStop(ctx)` | After Stop, before exit | Final cleanup, audit log close |
 
 {: .important}
 All resource cleanup belongs in `Stop()`. ColdBrew calls it after all servers have stopped and in-flight requests have completed (or timed out).
@@ -91,5 +96,7 @@ Make sure you configure your load balancer to stop sending new requests to your 
 [config]: https://pkg.go.dev/github.com/go-coldbrew/core/config#Config
 [CBStopper]: https://pkg.go.dev/github.com/go-coldbrew/core#CBStopper
 [CBGracefulStopper]: https://pkg.go.dev/github.com/go-coldbrew/core#CBGracefulStopper
+[CBPreStopper]: https://pkg.go.dev/github.com/go-coldbrew/core#CBPreStopper
+[CBPostStopper]: https://pkg.go.dev/github.com/go-coldbrew/core#CBPostStopper
 [Kubernetes]: https://kubernetes.io/
 [POSIX signals]: https://en.wikipedia.org/wiki/Signal_(IPC)#POSIX_signals

--- a/howto/signals.md
+++ b/howto/signals.md
@@ -55,6 +55,8 @@ ColdBrew provides optional interfaces for lifecycle hooks:
 
 | Interface | Method | When called | Use for |
 |-----------|--------|-------------|---------|
+| [CBPreStarter] | `PreStart(ctx)` | Before initGRPC/initHTTP | DB connections, auth setup, interceptor config |
+| [CBPostStarter] | `PostStart(ctx)` | After server goroutines launched | Service discovery registration, startup banner |
 | [CBPreStopper] | `PreStop(ctx)` | Before FailCheck | Deregister from service discovery, flush buffers |
 | [CBGracefulStopper] | `FailCheck(bool)` | Before drain wait | Mark service as not ready |
 | [CBStopper] | `Stop()` | After servers stopped | Close DB pools, flush metrics, drain producers |
@@ -96,6 +98,8 @@ Make sure you configure your load balancer to stop sending new requests to your 
 [config]: https://pkg.go.dev/github.com/go-coldbrew/core/config#Config
 [CBStopper]: https://pkg.go.dev/github.com/go-coldbrew/core#CBStopper
 [CBGracefulStopper]: https://pkg.go.dev/github.com/go-coldbrew/core#CBGracefulStopper
+[CBPreStarter]: https://pkg.go.dev/github.com/go-coldbrew/core#CBPreStarter
+[CBPostStarter]: https://pkg.go.dev/github.com/go-coldbrew/core#CBPostStarter
 [CBPreStopper]: https://pkg.go.dev/github.com/go-coldbrew/core#CBPreStopper
 [CBPostStopper]: https://pkg.go.dev/github.com/go-coldbrew/core#CBPostStopper
 [Kubernetes]: https://kubernetes.io/

--- a/howto/workers.md
+++ b/howto/workers.md
@@ -880,11 +880,69 @@ workers.RunWorker(ctx, myWorker)
 - **Distributed locking:** Use `DistributedLock` for periodic workers that should run on only one pod. The lock is acquired per cycle, not per worker lifetime.
 
 ## ColdBrew Integration
-{: .label .label-yellow }
-Planned — not yet available
-{: .d-inline-block }
 
-The workers package is standalone — any Go service can use it. ColdBrew integration via `CBServiceV2` is planned for a future core release, where workers will be started/stopped as part of the ColdBrew service lifecycle.
+The workers package is standalone — any Go service can use it directly via `workers.Run`. ColdBrew core also integrates workers into the service lifecycle via the [CBWorkerProvider] optional interface.
+
+### How it works
+
+Implement `Workers()` on your service to return worker definitions. ColdBrew discovers this at startup via type assertion and manages the workers alongside gRPC/HTTP servers:
+
+```go
+var _ core.CBWorkerProvider = (*cbSvc)(nil)
+
+func (s *cbSvc) Workers() []*workers.Worker {
+    return []*workers.Worker{
+        workers.NewWorker("cleanup").
+            HandlerFunc(s.cleanup).
+            Every(5 * time.Minute).
+            WithJitter(10),
+    }
+}
+```
+
+No changes to `main()` — `SetService` discovers the interface automatically.
+
+### Lifecycle
+
+```text
+PreStart → initGRPC → initHTTP → start workers → start servers → PostStart
+→ block → PreStop → FailCheck → drain → stop workers → stop servers → Stop → PostStop
+```
+
+Workers start before servers (can warm caches) and stop before servers stop (in-flight RPCs can still use worker-managed resources).
+
+### Delegation pattern
+
+In the [cookiecutter template], `cbSvc` in `main.go` is a thin adapter. Workers are defined in `service/service.go` where the business logic lives:
+
+```go
+// service/service.go — service owns its workers
+func (s *svc) Workers() []*workers.Worker {
+    return []*workers.Worker{
+        workers.NewWorker("cleanup").HandlerFunc(s.cleanup).Every(5 * time.Minute),
+    }
+}
+
+// main.go — adapter delegates via composite interface
+type serviceImpl interface {
+    Stop()
+    Workers() []*workers.Worker
+}
+
+type cbSvc struct {
+    impl serviceImpl
+}
+
+func (s *cbSvc) Workers() []*workers.Worker { return s.impl.Workers() }
+```
+
+### Readiness
+
+Workers and readiness are independent concerns. See [Readiness Patterns] for how to combine workers with health checks — from simple (Pattern 1) to worker-managed readiness (Pattern 3) to dynamic DB-driven workers (Pattern 4).
+
+[CBWorkerProvider]: https://pkg.go.dev/github.com/go-coldbrew/core#CBWorkerProvider
+[cookiecutter template]: /cookiecutter-reference
+[Readiness Patterns]: /howto/readiness
 
 [workers]: https://github.com/go-coldbrew/workers
 [suture]: https://github.com/thejerf/suture

--- a/howto/workers.md
+++ b/howto/workers.md
@@ -936,6 +936,23 @@ type cbSvc struct {
 func (s *cbSvc) Workers() []*workers.Worker { return s.impl.Workers() }
 ```
 
+### Alternative: workers.Run() directly
+
+The workers package is standalone — you can call `workers.Run()` from anywhere in your service or implementation. It works in any goroutine, any function, any context. The workers will stop when the context is cancelled.
+
+```go
+go workers.Run(ctx, []*workers.Worker{
+    workers.NewWorker("cleanup").HandlerFunc(s.cleanup).Every(5 * time.Minute),
+})
+```
+
+**When to use which:**
+
+| Approach | Shutdown ordering | Framework-managed | Best for |
+|---|---|---|---|
+| `CBWorkerProvider` | Workers stop before servers (guaranteed) | Yes | Production services with workers tied to the service lifecycle |
+| `workers.Run()` directly | Stops when context cancelled | No — you manage it | Standalone workers, quick prototyping, workers outside the service lifecycle |
+
 ### Readiness
 
 Workers and readiness are independent concerns. See [Readiness Patterns] for how to combine workers with health checks — from simple (Pattern 1) to worker-managed readiness (Pattern 3) to dynamic DB-driven workers (Pattern 4).

--- a/howto/workers.md
+++ b/howto/workers.md
@@ -941,9 +941,13 @@ func (s *cbSvc) Workers() []*workers.Worker { return s.impl.Workers() }
 The workers package is standalone — you can call `workers.Run()` from anywhere in your service or implementation. It works in any goroutine, any function, any context. The workers will stop when the context is cancelled.
 
 ```go
-go workers.Run(ctx, []*workers.Worker{
-    workers.NewWorker("cleanup").HandlerFunc(s.cleanup).Every(5 * time.Minute),
-})
+go func() {
+    if err := workers.Run(ctx, []*workers.Worker{
+        workers.NewWorker("cleanup").HandlerFunc(s.cleanup).Every(5 * time.Minute),
+    }); err != nil {
+        slog.Error("workers failed", "error", err)
+    }
+}()
 ```
 
 **When to use which:**

--- a/tests/content.spec.ts
+++ b/tests/content.spec.ts
@@ -142,6 +142,67 @@ test.describe("Readiness & Workers Integration", () => {
   });
 });
 
+test.describe("SEO", () => {
+  const pagesWithDescriptions = [
+    "/",
+    "/getting-started/",
+    "/architecture/",
+    "/config-reference/",
+    "/howto/",
+    "/integrations/",
+    "/faq/",
+    "/packages/",
+    "/howto/APIs/",
+    "/howto/workers/",
+    "/howto/readiness/",
+    "/howto/production/",
+    "/howto/interceptors/",
+    "/howto/auth/",
+  ];
+
+  for (const pagePath of pagesWithDescriptions) {
+    test(`${pagePath} has meta description`, async ({ page }) => {
+      await page.goto(pagePath);
+      const meta = page.locator('meta[name="description"]');
+      const content = await meta.getAttribute("content");
+      expect(content, `${pagePath} missing meta description`).toBeTruthy();
+      expect(
+        content!.length,
+        `${pagePath} description too short`
+      ).toBeGreaterThan(20);
+    });
+  }
+});
+
+test.describe("Table of Contents", () => {
+  const howtoPages = [
+    "/howto/APIs/",
+    "/howto/gRPC/",
+    "/howto/Log/",
+    "/howto/errors/",
+    "/howto/Tracing/",
+    "/howto/interceptors/",
+    "/howto/workers/",
+    "/howto/readiness/",
+    "/howto/production/",
+    "/howto/auth/",
+  ];
+
+  for (const pagePath of howtoPages) {
+    test(`${pagePath} has table of contents`, async ({ page }) => {
+      await page.goto(pagePath);
+      const toc = page.locator("#table-of-contents, .no_toc, #toc");
+      const hasTOC = (await toc.count()) > 0;
+      // just-the-docs renders TOC as a list with anchor links
+      const tocLinks = page.locator('nav[aria-label="Table of contents"] a, .no_toc + ol a, .no_toc + ul a');
+      expect(
+        hasTOC || (await tocLinks.count()) > 0,
+        `${pagePath} missing table of contents`
+      ).toBeTruthy();
+    });
+  }
+});
+
 test.describe("ASCII Diagrams", () => {
   test("home page renders architecture diagram in pre block", async ({
     page,

--- a/tests/content.spec.ts
+++ b/tests/content.spec.ts
@@ -112,6 +112,36 @@ test.describe("Callouts", () => {
   });
 });
 
+test.describe("Readiness & Workers Integration", () => {
+  test("readiness page renders all four patterns", async ({ page }) => {
+    await page.goto("/howto/readiness/");
+    const mainContent = page.locator("main, .main-content").first();
+    await expect(mainContent).toContainText("Pattern 1");
+    await expect(mainContent).toContainText("Pattern 2");
+    await expect(mainContent).toContainText("Pattern 3");
+    await expect(mainContent).toContainText("Pattern 4");
+    await expect(mainContent).toContainText("CBPreStarter");
+    await expect(mainContent).toContainText("CBWorkerProvider");
+    const codeBlocks = page.locator("pre code");
+    expect(await codeBlocks.count()).toBeGreaterThanOrEqual(4);
+  });
+
+  test("readiness page has choosing-a-pattern table", async ({ page }) => {
+    await page.goto("/howto/readiness/");
+    const tables = page.locator("table");
+    expect(await tables.count()).toBeGreaterThanOrEqual(1);
+  });
+
+  test("workers page has ColdBrew Integration section", async ({ page }) => {
+    await page.goto("/howto/workers/");
+    const mainContent = page.locator("main, .main-content").first();
+    await expect(mainContent).toContainText("ColdBrew Integration");
+    await expect(mainContent).toContainText("CBWorkerProvider");
+    await expect(mainContent).toContainText("Delegation pattern");
+    await expect(mainContent).toContainText("Readiness Patterns");
+  });
+});
+
 test.describe("ASCII Diagrams", () => {
   test("home page renders architecture diagram in pre block", async ({
     page,

--- a/tests/links.spec.ts
+++ b/tests/links.spec.ts
@@ -21,7 +21,17 @@ async function getInternalLinks(
 }
 
 test.describe("Internal Links", () => {
-  const pagesToCrawl = ["/", "/howto/APIs/", "/integrations/", "/packages/"];
+  const pagesToCrawl = [
+    "/",
+    "/howto/APIs/",
+    "/integrations/",
+    "/packages/",
+    "/howto/production/",
+    "/howto/workers/",
+    "/howto/readiness/",
+    "/architecture/",
+    "/config-reference/",
+  ];
 
   for (const pagePath of pagesToCrawl) {
     test(`all internal links on ${pagePath} resolve without errors`, async ({

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -29,6 +29,7 @@ const howtoPages = [
   "/howto/workers/",
   "/howto/private-modules/",
   "/howto/auth/",
+  "/howto/readiness/",
 ];
 
 test.describe("Page Loading", () => {


### PR DESCRIPTION
## Summary

- New `howto/readiness.md` page with 4 readiness patterns:
  - Pattern 1: Simple (most services)
  - Pattern 2: Block in PreStart (critical deps)
  - Pattern 3: Worker-managed readiness (eventual)
  - Pattern 4: Dynamic workers from DB (manager pattern)
- Updated `howto/workers.md` — replaced "ColdBrew Integration" placeholder with: CBWorkerProvider usage, lifecycle diagram, delegation pattern, readiness cross-link
- Playwright tests for new readiness page + updated workers integration section
- Navigation test updated with readiness page

## Depends on

- go-coldbrew/core#85 (optional interfaces)

## Test plan

- [ ] `npx playwright test` passes (requires local Jekyll server)
- [ ] Readiness page renders with all 4 patterns and choosing-a-pattern table
- [ ] Workers page ColdBrew Integration section shows CBWorkerProvider, delegation, lifecycle
- [ ] Cross-links between readiness and workers pages work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended FAQ with coverage of gRPC streaming, background workers (`CBWorkerProvider`), and HTTP gateway performance troubleshooting.
  * Added new "Readiness Patterns" guide covering four implementation patterns for Kubernetes readiness coordination.
  * Replaced workers integration placeholder with concrete documentation of service lifecycle integration.
  * Enhanced "How To" landing page with searchable table of topics and cross-references.
  * Added "Related" links sections to multiple guides for improved navigation.

* **Tests**
  * Expanded test coverage for new documentation pages and SEO/table-of-contents validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->