### PR TITLE
docs: correct workers tracing sampling description

### DIFF
--- a/howto/workers.md
+++ b/howto/workers.md
@@ -394,7 +394,7 @@ middleware.Recover(func(name string, v any) {
 
 ### Tracing
 
-Creates an OTEL span named `worker:<name>:cycle` for each tick. Records errors on the span. Worker spans are always sampled regardless of the global sampler — this prevents silent span drops when using `ParentBased(TraceIDRatioBased(...))`, where worker root spans (which have no incoming parent) would otherwise be probabilistically dropped.
+Creates an OTEL span named `worker:<name>:cycle` for each tick. Records errors on the span. Worker spans are typically trace roots (no incoming parent), so sampling is determined by the global `TracerProvider`'s sampler — if you use `ParentBased(TraceIDRatioBased(...))` with a low ratio, worker spans may be probabilistically dropped. Use `AlwaysSample()` for the worker `TracerProvider` if you need every cycle traced.
 
 The OTEL trace ID is automatically injected into the log context as `trace` for correlation with your tracing backend.
 


### PR DESCRIPTION
## Summary

The workers tracing docs claimed worker spans are "always sampled regardless of the global sampler" — this is no longer accurate. The current `middleware.Tracing()` implementation uses `tracing.NewInternalSpan` which respects the global sampler.

Updated the description to reflect actual behavior: worker spans are typically trace roots, so sampling follows the global `TracerProvider`'s sampler. If using `ParentBased(TraceIDRatioBased(...))` with a low ratio, worker spans may be dropped — users should configure `AlwaysSample()` if needed.

## Test plan

- [ ] Visual review — wording matches actual workers/middleware/tracing.go behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tracing documentation to clarify how `worker` spans are sampled by the global `TracerProvider` and provided guidance on configuring sampling strategies for worker cycles to ensure consistent tracing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->