### PR TITLE
docs: update production shutdown sequence with new lifecycle hooks

### DIFF
--- a/howto/production.md
+++ b/howto/production.md
@@ -177,14 +177,19 @@ Set `terminationGracePeriodSeconds` to at least `SHUTDOWN_DURATION_IN_SECONDS` t
 ColdBrew's shutdown sequence (bounded by `SHUTDOWN_DURATION_IN_SECONDS`, default 15s):
 
 1. Receive SIGTERM from Kubernetes
-2. `FailCheck(true)` on `CBGracefulStopper` services — `/readycheck` starts failing
-3. Wait `GRPC_GRACEFUL_DURATION_IN_SECONDS` (default: 7s, included in shutdown timeout) for the load balancer to drain
-4. Shutdown admin server if configured (`ADMIN_PORT`)
-5. Shutdown HTTP server (stop accepting new requests)
-6. `GracefulStop()` gRPC server (finish in-flight RPCs, reject new ones)
-7. Force-stop gRPC server if graceful shutdown didn't complete in time
-8. Call `Stop()` on `CBStopper` services — close database pools, flush metrics, drain message producers
-9. Exit
+2. `PreStop(ctx)` on `CBPreStopper` services — deregister from service discovery, flush buffers
+3. `FailCheck(true)` on `CBGracefulStopper` services — `/readycheck` starts failing
+4. Wait `GRPC_GRACEFUL_DURATION_IN_SECONDS` (default: 7s, included in shutdown timeout) for the load balancer to drain
+5. Cancel worker context — workers begin draining
+6. Shutdown admin server if configured (`ADMIN_PORT`)
+7. Shutdown HTTP server (stop accepting new requests)
+8. `GracefulStop()` gRPC server (finish in-flight RPCs, reject new ones)
+9. Force-stop gRPC server if graceful shutdown didn't complete in time
+10. Call `Stop()` on `CBStopper` services — close database pools, flush metrics, drain message producers
+11. `PostStop(ctx)` on `CBPostStopper` services — final cleanup, audit log close
+12. Exit
+
+See [Shutdown Lifecycle](/howto/signals) for the full interface table and [Readiness Patterns](/howto/readiness) for combining workers with health checks.
 
 Tune these values based on your service:
 

--- a/howto/production.md
+++ b/howto/production.md
@@ -174,7 +174,7 @@ Set `terminationGracePeriodSeconds` to at least `SHUTDOWN_DURATION_IN_SECONDS` t
 
 ## Graceful shutdown tuning
 
-Kubernetes first sends `SIGTERM`, then ColdBrew begins its in-process shutdown sequence, which is bounded by `SHUTDOWN_DURATION_IN_SECONDS` (default 15s):
+When pod termination begins, Kubernetes runs any configured `lifecycle.preStop` hook, then the kubelet sends `SIGTERM`. ColdBrew's in-process shutdown sequence then begins, bounded by `SHUTDOWN_DURATION_IN_SECONDS` (default 15s). Note: the `PreStop(ctx)` hook below refers to ColdBrew's [CBPreStopper] interface, not Kubernetes' `lifecycle.preStop`:
 
 1. `PreStop(ctx)` on `CBPreStopper` services — deregister from service discovery, flush buffers
 2. `FailCheck(true)` on `CBGracefulStopper` services — `/readycheck` starts failing
@@ -637,3 +637,4 @@ These are your responsibility to handle at the infrastructure level:
 - [Workers](/howto/workers) — background goroutine management with restart and metrics
 
 [ColdBrew cookiecutter]: /getting-started
+[CBPreStopper]: https://pkg.go.dev/github.com/go-coldbrew/core#CBPreStopper

--- a/howto/production.md
+++ b/howto/production.md
@@ -174,20 +174,19 @@ Set `terminationGracePeriodSeconds` to at least `SHUTDOWN_DURATION_IN_SECONDS` t
 
 ## Graceful shutdown tuning
 
-ColdBrew's shutdown sequence (bounded by `SHUTDOWN_DURATION_IN_SECONDS`, default 15s):
+Kubernetes first sends `SIGTERM`, then ColdBrew begins its in-process shutdown sequence, which is bounded by `SHUTDOWN_DURATION_IN_SECONDS` (default 15s):
 
-1. Receive SIGTERM from Kubernetes
-2. `PreStop(ctx)` on `CBPreStopper` services — deregister from service discovery, flush buffers
-3. `FailCheck(true)` on `CBGracefulStopper` services — `/readycheck` starts failing
-4. Wait `GRPC_GRACEFUL_DURATION_IN_SECONDS` (default: 7s, included in shutdown timeout) for the load balancer to drain
-5. Cancel worker context — workers begin draining
-6. Shutdown admin server if configured (`ADMIN_PORT`)
-7. Shutdown HTTP server (stop accepting new requests)
-8. `GracefulStop()` gRPC server (finish in-flight RPCs, reject new ones)
-9. Force-stop gRPC server if graceful shutdown didn't complete in time
-10. Call `Stop()` on `CBStopper` services — close database pools, flush metrics, drain message producers
-11. `PostStop(ctx)` on `CBPostStopper` services — final cleanup, audit log close
-12. Exit
+1. `PreStop(ctx)` on `CBPreStopper` services — deregister from service discovery, flush buffers
+2. `FailCheck(true)` on `CBGracefulStopper` services — `/readycheck` starts failing
+3. Wait `GRPC_GRACEFUL_DURATION_IN_SECONDS` (default: 7s, included in shutdown timeout) for the load balancer to drain
+4. Cancel worker context, wait for workers to exit
+5. Shutdown admin server if configured (`ADMIN_PORT`)
+6. Shutdown HTTP server (stop accepting new requests)
+7. `GracefulStop()` gRPC server (finish in-flight RPCs, reject new ones)
+8. Force-stop gRPC server if graceful shutdown didn't complete in time
+9. Call `Stop()` on `CBStopper` services — close database pools, flush metrics, drain message producers
+10. `PostStop(ctx)` on `CBPostStopper` services — final cleanup, audit log close
+11. Exit
 
 See [Shutdown Lifecycle](/howto/signals) for the full interface table and [Readiness Patterns](/howto/readiness) for combining workers with health checks.
 


### PR DESCRIPTION
## Summary

production.md still showed the old 9-step shutdown sequence. With core v0.2.0, the sequence has 12 steps including PreStop, worker cancel, and PostStop hooks.

This commit was originally pushed to #81 but didn't make it into the squash merge.

## Changes

- Update shutdown sequence to match actual `core.go` Stop() in v0.2.0
- Add cross-links to signals.md and readiness.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated graceful shutdown tuning documentation with a comprehensive termination flow description, detailing the full shutdown process steps and lifecycle phases.
  * Added cross-references to shutdown lifecycle and readiness patterns documentation for better production guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->