### PR TITLE
docs: document worker metrics defaults and AddWorkerRunOptions

### DIFF
--- a/howto/workers.md
+++ b/howto/workers.md
@@ -936,17 +936,17 @@ type cbSvc struct {
 func (s *cbSvc) Workers() []*workers.Worker { return s.impl.Workers() }
 ```
 
-### Metrics
+### Metrics defaults
 
 ColdBrew wires `workers.NewPrometheusMetrics(APP_NAME)` automatically when you adopt `CBWorkerProvider`. The default uses `APP_NAME` as the namespace, so `myapp_worker_started_total`, `myapp_worker_panicked_total`, `myapp_worker_active_count`, etc. appear on `/metrics` without any extra wiring.
 
 The default is skipped when `DISABLE_PROMETHEUS=true` or `APP_NAME` is empty (an empty namespace would produce ambiguous unprefixed metric names).
 
-To use a non-Prometheus backend (Datadog, StatsD, etc.) or a custom Prometheus namespace, override the default via `core.AddWorkerRunOptions` during init — same `Metrics` interface as the [Metrics section above](#metrics):
+To use a non-Prometheus backend (Datadog, StatsD, etc.) or a custom Prometheus namespace, override the default via `core.AddWorkerRunOptions` during init. The `Metrics` interface is the same one shown in the [standalone Metrics section](#metrics) earlier in this document:
 
 ```go
 func init() {
-    core.AddWorkerRunOptions(workers.WithMetrics(myDatadogMetrics{}))
+    core.AddWorkerRunOptions(workers.WithMetrics(&myDatadogMetrics{client: dd}))
 }
 ```
 

--- a/howto/workers.md
+++ b/howto/workers.md
@@ -954,7 +954,7 @@ func init() {
 
 ### Tracing and observability middleware (opt-in)
 
-Unlike gRPC, ColdBrew does **not** wire worker observability middleware automatically. The standard stack (`Recover`, `LogContext`, `Tracing`, `Slog`) is opt-in because tracing and slog produce one span and one log line per cycle — fine for slow periodic workers, noisy for fast ones. Enable it explicitly:
+Unlike gRPC, ColdBrew does **not** wire worker observability middleware automatically. The standard stack (`Recover`, `LogContext`, `Tracing`, `Slog`) is opt-in because tracing produces one span and `Slog` emits two log lines (start + end/error) per cycle — fine for slow periodic workers, noisy for fast ones. Enable it explicitly:
 
 ```go
 import "github.com/go-coldbrew/workers/middleware"

--- a/howto/workers.md
+++ b/howto/workers.md
@@ -950,7 +950,7 @@ func init() {
 }
 ```
 
-`AddWorkerRunOptions` also accepts other run-level options like `workers.WithDefaultJitter` and `workers.WithInterceptors` — anything that should apply framework-wide to every worker started by `core.Run()`. Per-worker `Worker.WithMetrics` still overrides the run-level default for individual workers.
+`AddWorkerRunOptions` also accepts other run-level options like `workers.WithDefaultJitter` and `workers.WithInterceptors` — anything that should apply framework-wide to every worker started by `cb.Run()`. Per-worker `Worker.WithMetrics` still overrides the run-level default for individual workers.
 
 ### Tracing and observability middleware (opt-in)
 
@@ -977,7 +977,7 @@ core.AddWorkerRunOptions(
 )
 ```
 
-Run-level interceptors wrap **outside** worker-level interceptors, so per-worker `Interceptors`/`AddInterceptors` still compose correctly. See the [Middleware section](#middleware) earlier in this document for individual middleware behaviour.
+Run-level interceptors wrap **outside** worker-level interceptors, so per-worker `Interceptors`/`AddInterceptors` still compose correctly. See the [Middleware section](#middleware) earlier in this document for individual middleware behavior.
 
 ### Alternative: workers.Run() directly
 

--- a/howto/workers.md
+++ b/howto/workers.md
@@ -936,6 +936,22 @@ type cbSvc struct {
 func (s *cbSvc) Workers() []*workers.Worker { return s.impl.Workers() }
 ```
 
+### Metrics
+
+ColdBrew wires `workers.NewPrometheusMetrics(APP_NAME)` automatically when you adopt `CBWorkerProvider`. The default uses `APP_NAME` as the namespace, so `myapp_worker_started_total`, `myapp_worker_panicked_total`, `myapp_worker_active_count`, etc. appear on `/metrics` without any extra wiring.
+
+The default is skipped when `DISABLE_PROMETHEUS=true` or `APP_NAME` is empty (an empty namespace would produce ambiguous unprefixed metric names).
+
+To use a non-Prometheus backend (Datadog, StatsD, etc.) or a custom Prometheus namespace, override the default via `core.AddWorkerRunOptions` during init — same `Metrics` interface as the [Metrics section above](#metrics):
+
+```go
+func init() {
+    core.AddWorkerRunOptions(workers.WithMetrics(myDatadogMetrics{}))
+}
+```
+
+`AddWorkerRunOptions` also accepts other run-level options like `workers.WithDefaultJitter` and `workers.WithInterceptors` — anything that should apply framework-wide to every worker started by `core.Run()`. Per-worker `Worker.WithMetrics` still overrides the run-level default for individual workers.
+
 ### Alternative: workers.Run() directly
 
 The workers package is standalone — you can call `workers.Run()` from anywhere in your service or implementation. It works in any goroutine, any function, any context. The workers will stop when the context is cancelled.

--- a/howto/workers.md
+++ b/howto/workers.md
@@ -952,6 +952,33 @@ func init() {
 
 `AddWorkerRunOptions` also accepts other run-level options like `workers.WithDefaultJitter` and `workers.WithInterceptors` — anything that should apply framework-wide to every worker started by `core.Run()`. Per-worker `Worker.WithMetrics` still overrides the run-level default for individual workers.
 
+### Tracing and observability middleware (opt-in)
+
+Unlike gRPC, ColdBrew does **not** wire worker observability middleware automatically. The standard stack (`Recover`, `LogContext`, `Tracing`, `Slog`) is opt-in because tracing and slog produce one span and one log line per cycle — fine for slow periodic workers, noisy for fast ones. Enable it explicitly:
+
+```go
+import "github.com/go-coldbrew/workers/middleware"
+
+func init() {
+    core.AddWorkerRunOptions(
+        workers.WithInterceptors(middleware.DefaultInterceptors()...),
+    )
+}
+```
+
+`DefaultInterceptors()` returns `[Recover, LogContext, Tracing, Slog]`. Pick a subset if some are too noisy for your workload — `middleware.Recover(nil)` and `middleware.LogContext()` are essentially free and recommended for any production service:
+
+```go
+core.AddWorkerRunOptions(
+    workers.WithInterceptors(
+        middleware.Recover(nil),
+        middleware.LogContext(),
+    ),
+)
+```
+
+Run-level interceptors wrap **outside** worker-level interceptors, so per-worker `Interceptors`/`AddInterceptors` still compose correctly. See the [Middleware section](#middleware) earlier in this document for individual middleware behaviour.
+
 ### Alternative: workers.Run() directly
 
 The workers package is standalone — you can call `workers.Run()` from anywhere in your service or implementation. It works in any goroutine, any function, any context. The workers will stop when the context is cancelled.


### PR DESCRIPTION
## Summary

- Adds a **Metrics** subsection under "ColdBrew Integration" in `howto/workers.md` documenting:
  - Core wires `workers.NewPrometheusMetrics(APP_NAME)` automatically — no extra wiring needed.
  - The default is skipped when `DISABLE_PROMETHEUS=true` or `APP_NAME` is empty.
  - How to override with `core.AddWorkerRunOptions(workers.WithMetrics(m))` for custom backends (Datadog, StatsD) or other run-level options (`WithDefaultJitter`, `WithInterceptors`).
- Tracks the API addition in [go-coldbrew/core#87](https://github.com/go-coldbrew/core/pull/87). This PR should land after that one merges, since it references the new public function.

## Test plan

- [ ] Build the Jekyll site locally and confirm the new subsection renders correctly under "ColdBrew Integration".
- [ ] `cd docs.coldbrew.cloud && npx playwright test` — no anchor or permalink changes were made, so navigation tests should be unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added two opt-in ColdBrew integration sections: default Prometheus worker metrics (can be disabled or renamed) and how to override metrics backend/namespace.
  * Clarified that worker observability middleware is not auto-wired for ColdBrew and added init-time examples for enabling and composing interceptors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->