### PR TITLE
docs: factual fixes from DOCS_REVIEW.md (Section A)

### DIFF
--- a/Index.md
+++ b/Index.md
@@ -35,7 +35,7 @@ A Kubernetes-native Go microservice framework for building production-grade gRPC
 | **Fast Serialization** | [vtprotobuf] codec enabled by default — faster gRPC marshalling with automatic fallback to standard protobuf |
 | **TLS with Auto-Reload** | Automatic certificate hot-reloading via [certinel](https://github.com/cloudflare/certinel) — updated certs are picked up without a restart; works with cert-manager and Vault symlink rotation |
 | **Kubernetes-native** | Health/ready probes, graceful SIGTERM shutdown, structured JSON logs, Prometheus metrics — all wired automatically |
-| **Service Lifecycle Hooks** | Optional `PreStart`/`PostStart`/`PreStop`/`Stop`/`PostStop` callbacks for setup, registration, draining, and cleanup — see [Shutdown Lifecycle](/howto/signals) |
+| **Service Lifecycle Hooks** | Optional `PreStart`/`PostStart`/`PreStop`/`Stop`/`PostStop` callbacks for setup, registration, draining, and cleanup — see [service lifecycle interfaces](/howto/signals#service-lifecycle-interfaces) |
 | **Swagger / OpenAPI** | Interactive API docs auto-served at `/swagger/` from your protobuf definitions |
 | **Profiling** | Go [pprof] endpoints at `/debug/pprof/` for CPU, memory, goroutine, and trace profiling |
 | **gRPC Reflection** | Server reflection enabled by default — works with [grpcurl], [grpcui], and Postman |

--- a/Index.md
+++ b/Index.md
@@ -35,6 +35,7 @@ A Kubernetes-native Go microservice framework for building production-grade gRPC
 | **Fast Serialization** | [vtprotobuf] codec enabled by default — faster gRPC marshalling with automatic fallback to standard protobuf |
 | **TLS with Auto-Reload** | Automatic certificate hot-reloading via [certinel](https://github.com/cloudflare/certinel) — updated certs are picked up without a restart; works with cert-manager and Vault symlink rotation |
 | **Kubernetes-native** | Health/ready probes, graceful SIGTERM shutdown, structured JSON logs, Prometheus metrics — all wired automatically |
+| **Service Lifecycle Hooks** | Optional `PreStart`/`PostStart`/`PreStop`/`Stop`/`PostStop` callbacks for setup, registration, draining, and cleanup — see [Shutdown Lifecycle](/howto/signals) |
 | **Swagger / OpenAPI** | Interactive API docs auto-served at `/swagger/` from your protobuf definitions |
 | **Profiling** | Go [pprof] endpoints at `/debug/pprof/` for CPU, memory, goroutine, and trace profiling |
 | **gRPC Reflection** | Server reflection enabled by default — works with [grpcurl], [grpcui], and Postman |
@@ -42,7 +43,7 @@ A Kubernetes-native Go microservice framework for building production-grade gRPC
 | **Container-aware Runtime** | Auto-tunes GOMAXPROCS to match container CPU limits via [automaxprocs] |
 | **Request Validation** | [Protovalidate] annotations enforced automatically on both gRPC and HTTP requests — define validation rules in your proto, get `InvalidArgument` errors for free |
 | **CI/CD Pipelines** | Ready-to-use [GitHub Actions] and [GitLab CI] workflows for build, test, lint, coverage, and benchmarks |
-| **Local Dev Stack** | Docker Compose with 19 services across 18 profiles + `obs` group (databases, caches, brokers, AWS/GCP emulators) — `make local-stack` starts your selection, `make local-stack-obs` adds [Prometheus], [Grafana], [Jaeger] |
+| **Local Dev Stack** | Docker Compose with 21 services across 18 single-service profiles plus the `obs` group profile (databases, caches, brokers, AWS/GCP emulators) — `make local-stack` starts your selection, `make local-stack-obs` adds [Prometheus], [Grafana], [Jaeger] |
 | **Application Metrics** | Interface-based metrics package with [promauto] registration — counter and histogram examples wired into handlers |
 | **Load Testing** | [ghz] gRPC load test config with `make loadtest` — results visible in Grafana dashboard when running with `make local-stack-obs` |
 

--- a/architecture.md
+++ b/architecture.md
@@ -375,24 +375,34 @@ func (s *svc) Echo(ctx context.Context, req *proto.EchoRequest) (*proto.EchoResp
 
 1. Configuration loaded from environment variables (`core.New(cfg)`)
 2. Interceptor chain assembled during `init()` (not thread-safe)
-3. gRPC server created, service registers handlers (`InitGRPC`)
-4. Unix socket created for gateway (if `DISABLE_UNIX_GATEWAY=false`)
-5. HTTP server created, service registers handlers (`InitHTTP`)
-6. gRPC and HTTP servers start listening concurrently
-7. Admin server starts (if `ADMIN_PORT` is set)
-8. Service marks itself as ready (`SetReady()`) — `/readycheck` starts succeeding
-9. Server blocks until shutdown signal
+3. `PreStart(ctx)` on services implementing [CBPreStarter] — DB connections, schema migrations, programmatic interceptor configuration. Returning an error aborts startup.
+4. gRPC server created, service registers handlers (`InitGRPC`)
+5. Unix socket created for gateway (if `DISABLE_UNIX_GATEWAY=false`)
+6. HTTP server created, service registers handlers (`InitHTTP`)
+7. gRPC and HTTP servers start listening concurrently
+8. Admin server starts (if `ADMIN_PORT` is set)
+9. `PostStart(ctx)` on services implementing [CBPostStarter] — service-discovery registration, post-startup metrics emission
+10. Service marks itself as ready (`SetReady()`) — `/readycheck` starts succeeding
+11. Server blocks until shutdown signal
 
 ### Shutdown Sequence
 
 1. SIGTERM/SIGINT received
-2. `FailCheck(true)` on `CBGracefulStopper` services — `/readycheck` starts failing
-3. Wait `GRPC_GRACEFUL_DURATION_IN_SECONDS` (default 7s) for load balancer to drain
-4. Shutdown admin server (if configured)
-5. Shutdown HTTP server (stop accepting new requests)
-6. `GracefulStop()` gRPC server (finish in-flight RPCs, reject new ones)
-7. Force-stop gRPC server if graceful shutdown didn't complete in time
-8. `Stop()` called on `CBStopper` services (your cleanup logic)
-9. Exit
+2. `PreStop(ctx)` on services implementing [CBPreStopper] — deregister from service discovery, flush buffers
+3. `FailCheck(true)` on `CBGracefulStopper` services — `/readycheck` starts failing
+4. Wait `GRPC_GRACEFUL_DURATION_IN_SECONDS` (default 7s) for load balancer to drain
+5. Cancel worker context, wait for workers to exit
+6. Shutdown admin server (if configured)
+7. Shutdown HTTP server (stop accepting new requests)
+8. `GracefulStop()` gRPC server (finish in-flight RPCs, reject new ones)
+9. Force-stop gRPC server if graceful shutdown didn't complete in time
+10. `Stop()` called on `CBStopper` services (your cleanup logic)
+11. `PostStop(ctx)` on services implementing [CBPostStopper] — final cleanup, audit log close
+12. Exit
 
-See [Signal Handling and Graceful Shutdown](/howto/signals) for configuration and tuning details.
+See [Signal Handling and Graceful Shutdown](/howto/signals) for the full lifecycle interface table, configuration, and tuning details.
+
+[CBPreStarter]: https://pkg.go.dev/github.com/go-coldbrew/core#CBPreStarter
+[CBPostStarter]: https://pkg.go.dev/github.com/go-coldbrew/core#CBPostStarter
+[CBPreStopper]: https://pkg.go.dev/github.com/go-coldbrew/core#CBPreStopper
+[CBPostStopper]: https://pkg.go.dev/github.com/go-coldbrew/core#CBPostStopper

--- a/howto/Tracing.md
+++ b/howto/Tracing.md
@@ -20,9 +20,9 @@ Its possible for you to have multiple backends enabled at the same time, for exa
 
 ## Adding Tracing to your functions
 
-ColdBrew provides a way to add tracing to your functions using the [go-coldbrew/tracing] package. The Package provides function like `NewInternalSpan/NewExternalSpan/NewDatabaseSpan` which will create a new span and add it to the context.
+ColdBrew provides a way to add tracing to your functions using the [go-coldbrew/tracing] package. The Package provides function like `NewInternalSpan/NewExternalSpan/NewDatastoreSpan` which will create a new span and add it to the context.
 
-Make sure you use the context returned from the `NewInternalSpan/NewExternalSpan/NewDatabaseSpan` functions. This is because the span is added to the context. If you don't use the context returned from the function, new spans will not be add at the correct place in the trace.
+Make sure you use the context returned from the `NewInternalSpan/NewExternalSpan/NewDatastoreSpan` functions. This is because the span is added to the context. If you don't use the context returned from the function, new spans will not be add at the correct place in the trace.
 
 You can also add tags to the span using the `SetTag/SetQuery/SetError` function. These tags will be added to the span and will be visible in the trace view of your tracing system (e.g. New Relic / OpenTelemetry).
 

--- a/howto/Tracing.md
+++ b/howto/Tracing.md
@@ -20,9 +20,9 @@ Its possible for you to have multiple backends enabled at the same time, for exa
 
 ## Adding Tracing to your functions
 
-ColdBrew provides a way to add tracing to your functions using the [go-coldbrew/tracing] package. The Package provides function like `NewInternalSpan/NewExternalSpan/NewDatastoreSpan` which will create a new span and add it to the context.
+ColdBrew provides a way to add tracing to your functions using the [go-coldbrew/tracing] package. The package provides functions like `NewInternalSpan`, `NewExternalSpan`, and `NewDatastoreSpan` which create a new span and add it to the context.
 
-Make sure you use the context returned from the `NewInternalSpan/NewExternalSpan/NewDatastoreSpan` functions. This is because the span is added to the context. If you don't use the context returned from the function, new spans will not be add at the correct place in the trace.
+Make sure you use the context returned from the `NewInternalSpan`, `NewExternalSpan`, and `NewDatastoreSpan` functions. This is because the span is added to the context. If you don't use the context returned from the function, new spans will not be added at the correct place in the trace.
 
 You can also add tags to the span using the `SetTag/SetQuery/SetError` function. These tags will be added to the span and will be visible in the trace view of your tracing system (e.g. New Relic / OpenTelemetry).
 

--- a/howto/local-dev.md
+++ b/howto/local-dev.md
@@ -13,7 +13,7 @@ description: "Docker Compose local dev stack with per-service profiles for datab
 
 ## Overview
 
-Projects generated from the [ColdBrew cookiecutter] include a `docker-compose.local.yml` with 19 infrastructure services across 18 individual profiles plus one group profile (`obs` for Prometheus + Grafana + Jaeger). You select which profiles to start — only those containers run.
+Projects generated from the [ColdBrew cookiecutter] include a `docker-compose.local.yml` with 21 infrastructure services across 18 single-service profiles plus the `obs` group profile (Prometheus + Grafana + Jaeger). You select which profiles to start — only those containers run.
 
 Your app runs natively via `make run` (fast builds, no Docker overhead). The compose stack provides only infrastructure dependencies.
 

--- a/howto/production.md
+++ b/howto/production.md
@@ -172,6 +172,15 @@ Both return JSON with build/version info on success. During graceful shutdown, `
 {: .important }
 Set `terminationGracePeriodSeconds` to at least `SHUTDOWN_DURATION_IN_SECONDS` to avoid SIGKILL during shutdown. The drain wait (`GRPC_GRACEFUL_DURATION_IN_SECONDS`) is included within the shutdown timeout, not additional to it. With the default of 15s, a value of 20 provides a safe buffer.
 
+## Startup lifecycle
+
+ColdBrew exposes two optional interfaces for one-time startup work, symmetric to the shutdown hooks below:
+
+1. `PreStart(ctx) error` on services implementing [CBPreStarter] — runs **before** `InitGRPC`/`InitHTTP`. Returning an error aborts startup, so this is the right place for required dependencies that must be ready before traffic is accepted: database pool initialization, schema migrations, programmatic interceptor configuration via `interceptors.Set*()` functions, blocking auth-key warmup.
+2. `PostStart(ctx)` on services implementing [CBPostStarter] — runs **after** servers are listening. Use it for fire-and-forget setup that doesn't gate readiness: service-discovery registration, post-startup metrics emission, startup banners.
+
+Order: `PreStart → InitGRPC/InitHTTP → server listen → PostStart → SetReady`. See [Readiness Patterns](/howto/readiness) for blocking on dependencies in `PreStart`, and [Shutdown Lifecycle](/howto/signals#service-lifecycle-interfaces) for the full interface table.
+
 ## Graceful shutdown tuning
 
 When pod termination begins, Kubernetes runs any configured `lifecycle.preStop` hook, then the kubelet sends `SIGTERM`. ColdBrew's in-process shutdown sequence then begins, bounded by `SHUTDOWN_DURATION_IN_SECONDS` (default 15s). Note: the `PreStop(ctx)` hook below refers to ColdBrew's [CBPreStopper] interface, not Kubernetes' `lifecycle.preStop`:
@@ -637,4 +646,6 @@ These are your responsibility to handle at the infrastructure level:
 - [Workers](/howto/workers) — background goroutine management with restart and metrics
 
 [ColdBrew cookiecutter]: /getting-started
+[CBPreStarter]: https://pkg.go.dev/github.com/go-coldbrew/core#CBPreStarter
+[CBPostStarter]: https://pkg.go.dev/github.com/go-coldbrew/core#CBPostStarter
 [CBPreStopper]: https://pkg.go.dev/github.com/go-coldbrew/core#CBPreStopper

--- a/howto/signals.md
+++ b/howto/signals.md
@@ -55,7 +55,7 @@ ColdBrew provides optional interfaces for lifecycle hooks:
 
 | Interface | Method | When called | Use for |
 |-----------|--------|-------------|---------|
-| [CBPreStarter] | `PreStart(ctx)` | Before initGRPC/initHTTP | DB connections, auth setup, interceptor config |
+| [CBPreStarter] | `PreStart(ctx) error` | Before initGRPC/initHTTP | DB connections, auth setup, interceptor config (returning error aborts startup) |
 | [CBPostStarter] | `PostStart(ctx)` | After server goroutines launched | Service discovery registration, startup banner |
 | [CBPreStopper] | `PreStop(ctx)` | Before FailCheck | Deregister from service discovery, flush buffers |
 | [CBGracefulStopper] | `FailCheck(bool)` | Before drain wait | Mark service as not ready |

--- a/tests/content.spec.ts
+++ b/tests/content.spec.ts
@@ -142,6 +142,37 @@ test.describe("Readiness & Workers Integration", () => {
   });
 });
 
+test.describe("Factual accuracy", () => {
+  test("Tracing howto uses NewDatastoreSpan (not NewDatabaseSpan)", async ({ page }) => {
+    await page.goto("/howto/Tracing/");
+    const pageText = await page.locator("main, .main-content").first().textContent();
+    expect(pageText).toContain("NewDatastoreSpan");
+    expect(pageText).not.toContain("NewDatabaseSpan");
+  });
+
+  test("home page advertises correct local-stack counts", async ({ page }) => {
+    await page.goto("/");
+    const pageText = await page.locator("main, .main-content").first().textContent();
+    expect(pageText).toContain("21 services");
+    expect(pageText).toContain("18 single-service profiles");
+  });
+
+  test("local-dev page advertises correct local-stack counts", async ({ page }) => {
+    await page.goto("/howto/local-dev/");
+    const pageText = await page.locator("main, .main-content").first().textContent();
+    expect(pageText).toContain("21 infrastructure services");
+    expect(pageText).toContain("18 single-service profiles");
+  });
+
+  test("production page documents startup lifecycle hooks", async ({ page }) => {
+    await page.goto("/howto/production/");
+    const mainContent = page.locator("main, .main-content").first();
+    await expect(mainContent).toContainText("Startup lifecycle");
+    await expect(mainContent).toContainText("CBPreStarter");
+    await expect(mainContent).toContainText("CBPostStarter");
+  });
+});
+
 test.describe("SEO", () => {
   const pagesWithDescriptions = [
     "/",


### PR DESCRIPTION
## Summary

Three factual fixes from [DOCS_REVIEW.md](https://github.com/go-coldbrew/.github) Section A. All verified against upstream `main` of each repo.

### A1 — Tracing howto used a non-existent function name
- `howto/Tracing.md` lines 23, 25 referenced `NewDatabaseSpan` in prose.
- The actual function in `go-coldbrew/tracing/tracing.go` is `NewDatastoreSpan` (the same page used the correct name in the code sample at L89 and the link reference at L308).
- **Fix:** rename in prose to match the rest of the page.

### A2 — Local-stack service/profile counts were wrong on three pages
- Source of truth: `cookiecutter-coldbrew/{{cookiecutter.app_name}}/docker-compose.local.yml` defines **21 services** across **18 single-service profiles** plus the **`obs`** group profile (Prometheus, Grafana, Jaeger).
- `Index.md:45` said "19 services across 18 profiles + `obs` group" ❌
- `howto/local-dev.md:16` said "19 infrastructure services across 18 individual profiles plus one group profile" ❌
- `quickstart.md` was already correct.
- **Fix:** standardize wording across both pages.

### A3 — Startup lifecycle hooks were under-documented in two pages
`signals.md` and `readiness.md` already cover `CBPreStarter`/`CBPostStarter` thoroughly. The remaining gaps:
- `howto/production.md` covered shutdown hooks but not startup hooks → added a new **Startup lifecycle** subsection symmetric to the existing graceful-shutdown coverage.
- `architecture.md` startup/shutdown sequences listed numbered steps without naming the lifecycle hooks → both sequences now name all six hooks (`PreStart`, `PostStart`, `PreStop`, `FailCheck`, `Stop`, `PostStop`) with godoc links.
- `Index.md` "What You Get Out of the Box" → new **Service Lifecycle Hooks** feature row.

### Tests
New `tests/content.spec.ts` "Factual accuracy" describe block asserts:
- `/howto/Tracing/` contains `NewDatastoreSpan` and not `NewDatabaseSpan`
- Home page and `/howto/local-dev/` contain "21 services" / "18 single-service profiles"
- `/howto/production/` contains "Startup lifecycle", "CBPreStarter", "CBPostStarter"

This locks the corrected wording so the same drift can't happen again.

## Test plan
- [ ] `bundle exec jekyll build` succeeds with no broken-link warnings
- [ ] `npx playwright test tests/content.spec.ts` — new "Factual accuracy" tests pass against a local Jekyll server
- [ ] Spot-check on the rendered site: `/howto/Tracing/`, `/howto/local-dev/`, `/howto/production/`, `/architecture/`, `/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Enhanced lifecycle hooks documentation: added PreStart/PostStart/PreStop/Stop/PostStop callback guidance for service initialization and shutdown sequences
* Updated Local Dev Stack composition details: infrastructure service count adjusted to 21, with clarified 18 single-service profiles
* Refined production startup sequence documentation to include lifecycle hook execution order
* Updated tracing documentation terminology for consistency

## Tests

* Added content correctness validation tests covering documentation key terms and infrastructure details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->