### PR TITLE
docs: regroup howto index + augment production checklist

### DIFF
--- a/howto/gRPC.md
+++ b/howto/gRPC.md
@@ -100,8 +100,6 @@ When your service makes outbound gRPC calls, three concerns usually come up toge
 - **Per-call timeouts** — pass a deadline via `context.WithTimeout` on the client side and call the returned `cancel` (typically `defer cancel()`) so the timer is released as soon as the call returns. The server-side default is `GRPC_SERVER_DEFAULT_TIMEOUT_IN_SECONDS` (see [Configuration Reference](/config-reference)).
 - **Client-side tracing and metrics** — the default client interceptors propagate the trace ID and emit `grpc_client_*` Prometheus metrics automatically. See [Interceptors](/howto/interceptors#adding-interceptors-to-your-grpc-client) to add your own.
 
-[failsafe-go]: https://github.com/failsafe-go/failsafe-go
-
 ## Wrapping existing connections
 
 You can also use existing gRPC connections with [grpcpool] by wrapping it with [grpcpool.New] function.
@@ -149,3 +147,4 @@ func main() {
 [grpcpool.Dial]: https://pkg.go.dev/github.com/go-coldbrew/grpcpool#Dial
 [grpc.ClientConnInterface]: https://pkg.go.dev/google.golang.org/grpc#ClientConnInterface
 [grpcpool.New]: https://pkg.go.dev/github.com/go-coldbrew/grpcpool#New
+[failsafe-go]: https://github.com/failsafe-go/failsafe-go

--- a/howto/gRPC.md
+++ b/howto/gRPC.md
@@ -92,6 +92,18 @@ func main() {
 }
 ```
 
+## Calling other services
+
+When your service makes outbound gRPC calls, three concerns usually come up together — the connection pool above handles transport, and these handle reliability:
+
+- **Circuit breaking and retries** — register an executor with `interceptors.SetDefaultExecutor` and bring your own resilience library ([failsafe-go] is recommended). See [Circuit Breaker / Resilience](/integrations/#circuit-breaker--resilience) for the full setup, per-method circuit breakers, and excluded errors.
+- **Per-call timeouts** — pass a deadline via `context.WithTimeout` on the client side. The server-side default is `GRPC_SERVER_DEFAULT_TIMEOUT_IN_SECONDS` (see [Configuration Reference](/config-reference)).
+- **Client-side tracing and metrics** — the default client interceptors propagate the trace ID and emit `grpc_client_*` Prometheus metrics automatically. See [Interceptors](/howto/interceptors#adding-interceptors-to-your-grpc-client) to add your own.
+
+[failsafe-go]: https://github.com/failsafe-go/failsafe-go
+
+## Wrapping existing connections
+
 You can also use existing gRPC connections with [grpcpool] by wrapping it with [grpcpool.New] function.
 
 ```go

--- a/howto/gRPC.md
+++ b/howto/gRPC.md
@@ -97,7 +97,7 @@ func main() {
 When your service makes outbound gRPC calls, three concerns usually come up together — the connection pool above handles transport, and these handle reliability:
 
 - **Circuit breaking and retries** — register an executor with `interceptors.SetDefaultExecutor` and bring your own resilience library ([failsafe-go] is recommended). See [Circuit Breaker / Resilience](/integrations/#circuit-breaker--resilience) for the full setup, per-method circuit breakers, and excluded errors.
-- **Per-call timeouts** — pass a deadline via `context.WithTimeout` on the client side. The server-side default is `GRPC_SERVER_DEFAULT_TIMEOUT_IN_SECONDS` (see [Configuration Reference](/config-reference)).
+- **Per-call timeouts** — pass a deadline via `context.WithTimeout` on the client side and call the returned `cancel` (typically `defer cancel()`) so the timer is released as soon as the call returns. The server-side default is `GRPC_SERVER_DEFAULT_TIMEOUT_IN_SECONDS` (see [Configuration Reference](/config-reference)).
 - **Client-side tracing and metrics** — the default client interceptors propagate the trace ID and emit `grpc_client_*` Prometheus metrics automatically. See [Interceptors](/howto/interceptors#adding-interceptors-to-your-grpc-client) to add your own.
 
 [failsafe-go]: https://github.com/failsafe-go/failsafe-go

--- a/howto/index.md
+++ b/howto/index.md
@@ -22,9 +22,9 @@ Designing and writing your service.
 | Add structured logging | [Log](/howto/Log) |
 | Handle errors with stack traces | [Errors](/howto/errors) |
 | Customize the interceptor chain | [Interceptors](/howto/interceptors) |
-| Add JWT / API key auth | [Authentication](/howto/auth) |
-| Run background workers | [Workers](/howto/workers) |
 | Use dependency injection | [Data Builder](/howto/data-builder) |
+| Run background workers | [Workers](/howto/workers) |
+| Add JWT / API key auth | [Authentication](/howto/auth) |
 | Add custom HTTP marshalers or middleware | [HTTP Gateway Extensions](/howto/gateway-extensions) |
 
 ## Operate
@@ -33,12 +33,12 @@ Running, observing, and shipping your service.
 
 | I want to... | Read |
 |---|---|
+| Add distributed tracing | [Tracing](/howto/Tracing) |
+| Expose Prometheus metrics | [Metrics](/howto/Metrics) |
+| Debug requests in production | [Debugging](/howto/Debugging) |
+| Handle graceful shutdown | [Signals](/howto/signals) |
 | Deploy to Kubernetes | [Production](/howto/production) |
 | Manage readiness with workers | [Readiness Patterns](/howto/readiness) |
-| Handle graceful shutdown | [Signals](/howto/signals) |
-| Expose Prometheus metrics | [Metrics](/howto/Metrics) |
-| Add distributed tracing | [Tracing](/howto/Tracing) |
-| Debug requests in production | [Debugging](/howto/Debugging) |
 
 ## Integrate
 
@@ -46,10 +46,10 @@ Connecting ColdBrew to your local environment, repo, and dependencies.
 
 | I want to... | Read |
 |---|---|
-| Set up local dev with Docker | [Local Development](/howto/local-dev) |
-| Use private Go modules | [Private Modules](/howto/private-modules) |
-| Write tests and benchmarks | [Testing](/howto/testing) |
 | Serve Swagger/OpenAPI UI | [Swagger](/howto/swagger) |
+| Write tests and benchmarks | [Testing](/howto/testing) |
+| Use private Go modules | [Private Modules](/howto/private-modules) |
+| Set up local dev with Docker | [Local Development](/howto/local-dev) |
 
 ## Advanced
 

--- a/howto/index.md
+++ b/howto/index.md
@@ -9,7 +9,11 @@ has_toc: true
 ---
 # How To
 
-Step-by-step guides for building, running, and operating ColdBrew services.
+Step-by-step guides for building, running, and operating ColdBrew services. The guides are grouped by what you are trying to do — pick the one that matches your task.
+
+## Build
+
+Designing and writing your service.
 
 | I want to... | Read |
 |---|---|
@@ -17,22 +21,43 @@ Step-by-step guides for building, running, and operating ColdBrew services.
 | Set up gRPC connection pooling | [gRPC](/howto/gRPC) |
 | Add structured logging | [Log](/howto/Log) |
 | Handle errors with stack traces | [Errors](/howto/errors) |
-| Add distributed tracing | [Tracing](/howto/Tracing) |
-| Expose Prometheus metrics | [Metrics](/howto/Metrics) |
 | Customize the interceptor chain | [Interceptors](/howto/interceptors) |
-| Debug requests in production | [Debugging](/howto/Debugging) |
-| Handle graceful shutdown | [Signals](/howto/signals) |
-| Serve Swagger/OpenAPI UI | [Swagger](/howto/swagger) |
-| Use dependency injection | [Data Builder](/howto/data-builder) |
-| Optimize protobuf serialization | [vtprotobuf](/howto/vtproto) |
-| Deploy to Kubernetes | [Production](/howto/production) |
-| Write tests and benchmarks | [Testing](/howto/testing) |
-| Run background workers | [Workers](/howto/workers) |
-| Use private Go modules | [Private Modules](/howto/private-modules) |
-| Manage readiness with workers | [Readiness Patterns](/howto/readiness) |
-| Set up local dev with Docker | [Local Development](/howto/local-dev) |
 | Add JWT / API key auth | [Authentication](/howto/auth) |
+| Run background workers | [Workers](/howto/workers) |
+| Use dependency injection | [Data Builder](/howto/data-builder) |
 | Add custom HTTP marshalers or middleware | [HTTP Gateway Extensions](/howto/gateway-extensions) |
+
+## Operate
+
+Running, observing, and shipping your service.
+
+| I want to... | Read |
+|---|---|
+| Deploy to Kubernetes | [Production](/howto/production) |
+| Manage readiness with workers | [Readiness Patterns](/howto/readiness) |
+| Handle graceful shutdown | [Signals](/howto/signals) |
+| Expose Prometheus metrics | [Metrics](/howto/Metrics) |
+| Add distributed tracing | [Tracing](/howto/Tracing) |
+| Debug requests in production | [Debugging](/howto/Debugging) |
+
+## Integrate
+
+Connecting ColdBrew to your local environment, repo, and dependencies.
+
+| I want to... | Read |
+|---|---|
+| Set up local dev with Docker | [Local Development](/howto/local-dev) |
+| Use private Go modules | [Private Modules](/howto/private-modules) |
+| Write tests and benchmarks | [Testing](/howto/testing) |
+| Serve Swagger/OpenAPI UI | [Swagger](/howto/swagger) |
+
+## Advanced
+
+Tuning, optimization, and topics most readers can skip on first pass.
+
+| I want to... | Read |
+|---|---|
+| Optimize protobuf serialization | [vtprotobuf](/howto/vtproto) |
 
 If you have a How To that you would like to share, please [open an issue](https://github.com/go-coldbrew/docs.coldbrew.cloud/issues)
 

--- a/howto/production.md
+++ b/howto/production.md
@@ -620,7 +620,7 @@ These are your responsibility to handle at the infrastructure level:
 - [ ] Set up error tracking (`SENTRY_DSN` or equivalent)
 - [ ] Configure tracing (`OTLP_ENDPOINT` or `NEW_RELIC_LICENSE_KEY`)
 - [ ] Ship logs to a centralized sink (Loki, Elastic, Datadog, etc.) so the trace ID in each line is searchable across pods
-- [ ] If serving TLS, point `TLS_CERT_PATH`/`TLS_KEY_PATH` at the cert-manager / Vault symlink so [auto-reload](/howto/production#tls) picks up rotations
+- [ ] If serving TLS, point `GRPC_TLS_CERT_FILE`/`GRPC_TLS_KEY_FILE` at the cert-manager / Vault symlink so [auto-reload](/howto/production#tls) picks up rotations
 - [ ] Use headless Service or L7 proxy for gRPC load balancing
 - [ ] Set resource requests and limits
 - [ ] Store secrets in Kubernetes Secrets, not environment variable literals

--- a/howto/production.md
+++ b/howto/production.md
@@ -614,13 +614,13 @@ These are your responsibility to handle at the infrastructure level:
 
 - [ ] Set `APP_NAME` and `ENVIRONMENT` for log/metric identification
 - [ ] Configure `livenessProbe` on `/healthcheck` and `readinessProbe` on `/readycheck`
-- [ ] Set `terminationGracePeriodSeconds` ≥ `SHUTDOWN_DURATION_IN_SECONDS` so graceful shutdown completes before SIGKILL
+- [ ] Set `terminationGracePeriodSeconds` to at least `SHUTDOWN_DURATION_IN_SECONDS` so graceful shutdown completes before SIGKILL
 - [ ] Enable Prometheus scraping (annotation or ServiceMonitor)
 - [ ] Wire alerts on the four signals every service needs: error-rate spike, p99 latency burn, restart count, OOM kills (see [Key metrics to alert on](#key-metrics-to-alert-on))
 - [ ] Set up error tracking (`SENTRY_DSN` or equivalent)
 - [ ] Configure tracing (`OTLP_ENDPOINT` or `NEW_RELIC_LICENSE_KEY`)
 - [ ] Ship logs to a centralized sink (Loki, Elastic, Datadog, etc.) so the trace ID in each line is searchable across pods
-- [ ] If serving TLS, point `GRPC_TLS_CERT_FILE`/`GRPC_TLS_KEY_FILE` at the cert-manager / Vault symlink so [auto-reload](/howto/production#tls) picks up rotations
+- [ ] If serving TLS, point `GRPC_TLS_CERT_FILE`/`GRPC_TLS_KEY_FILE` at the cert-manager / Vault symlink so [auto-reload](#tls) picks up rotations
 - [ ] Use headless Service or L7 proxy for gRPC load balancing
 - [ ] Set resource requests and limits
 - [ ] Store secrets in Kubernetes Secrets, not environment variable literals

--- a/howto/production.md
+++ b/howto/production.md
@@ -614,13 +614,18 @@ These are your responsibility to handle at the infrastructure level:
 
 - [ ] Set `APP_NAME` and `ENVIRONMENT` for log/metric identification
 - [ ] Configure `livenessProbe` on `/healthcheck` and `readinessProbe` on `/readycheck`
-- [ ] Set `terminationGracePeriodSeconds` ≥ shutdown + healthcheck wait duration
+- [ ] Set `terminationGracePeriodSeconds` ≥ `SHUTDOWN_DURATION_IN_SECONDS` so graceful shutdown completes before SIGKILL
 - [ ] Enable Prometheus scraping (annotation or ServiceMonitor)
+- [ ] Wire alerts on the four signals every service needs: error-rate spike, p99 latency burn, restart count, OOM kills (see [Key metrics to alert on](#key-metrics-to-alert-on))
 - [ ] Set up error tracking (`SENTRY_DSN` or equivalent)
 - [ ] Configure tracing (`OTLP_ENDPOINT` or `NEW_RELIC_LICENSE_KEY`)
+- [ ] Ship logs to a centralized sink (Loki, Elastic, Datadog, etc.) so the trace ID in each line is searchable across pods
+- [ ] If serving TLS, point `TLS_CERT_PATH`/`TLS_KEY_PATH` at the cert-manager / Vault symlink so [auto-reload](/howto/production#tls) picks up rotations
 - [ ] Use headless Service or L7 proxy for gRPC load balancing
 - [ ] Set resource requests and limits
 - [ ] Store secrets in Kubernetes Secrets, not environment variable literals
+- [ ] Set `ADMIN_PORT` if `/metrics`, `/debug/pprof`, and `/swagger` should be on a separate (non-public) port — see [Dedicated admin port](#dedicated-admin-port-recommended)
+- [ ] Have a rollout plan — canary, blue-green, or progressive rollout — so a bad deploy doesn't take down all replicas at once
 - [ ] Run `make lint` (includes `govulncheck`) before deploying
 - [ ] For high-QPS services: set `RESPONSE_TIME_LOG_ERROR_ONLY=true` to skip per-request logging on successful RPCs (see [tuning impact](/config-reference#measured-tuning-impact))
 

--- a/tests/content.spec.ts
+++ b/tests/content.spec.ts
@@ -171,6 +171,34 @@ test.describe("Factual accuracy", () => {
     await expect(mainContent).toContainText("CBPreStarter");
     await expect(mainContent).toContainText("CBPostStarter");
   });
+
+  test("howto index is grouped by audience", async ({ page }) => {
+    await page.goto("/howto/");
+    const mainContent = page.locator("main, .main-content").first();
+    await expect(mainContent.getByRole("heading", { name: "Build" })).toBeVisible();
+    await expect(mainContent.getByRole("heading", { name: "Operate" })).toBeVisible();
+    await expect(mainContent.getByRole("heading", { name: "Integrate" })).toBeVisible();
+    await expect(mainContent.getByRole("heading", { name: "Advanced" })).toBeVisible();
+  });
+
+  test("gRPC howto links the resilience and timeout topics", async ({ page }) => {
+    await page.goto("/howto/gRPC/");
+    const mainContent = page.locator("main, .main-content").first();
+    await expect(mainContent).toContainText("Calling other services");
+    await expect(mainContent).toContainText("Circuit Breaker / Resilience");
+    await expect(mainContent).toContainText("GRPC_SERVER_DEFAULT_TIMEOUT_IN_SECONDS");
+  });
+
+  test("production checklist covers the documented operational gates", async ({ page }) => {
+    await page.goto("/howto/production/");
+    const mainContent = page.locator("main, .main-content").first();
+    await expect(mainContent).toContainText("Production checklist");
+    await expect(mainContent).toContainText("p99 latency");
+    await expect(mainContent).toContainText("OOM");
+    await expect(mainContent).toContainText("centralized sink");
+    await expect(mainContent).toContainText("ADMIN_PORT");
+    await expect(mainContent).toContainText("canary");
+  });
 });
 
 test.describe("SEO", () => {

--- a/tests/content.spec.ts
+++ b/tests/content.spec.ts
@@ -185,8 +185,15 @@ test.describe("Factual accuracy", () => {
     await page.goto("/howto/gRPC/");
     const mainContent = page.locator("main, .main-content").first();
     await expect(mainContent).toContainText("Calling other services");
-    await expect(mainContent).toContainText("Circuit Breaker / Resilience");
     await expect(mainContent).toContainText("GRPC_SERVER_DEFAULT_TIMEOUT_IN_SECONDS");
+    // Assert the actual hrefs so this test fails if a link is dropped or
+    // re-pointed, not just if the surrounding prose is reworded.
+    await expect(
+      mainContent.getByRole("link", { name: "Circuit Breaker / Resilience" })
+    ).toHaveAttribute("href", "/integrations/#circuit-breaker--resilience");
+    await expect(
+      mainContent.getByRole("link", { name: "Configuration Reference" })
+    ).toHaveAttribute("href", "/config-reference");
   });
 
   test("production checklist covers the documented operational gates", async ({ page }) => {


### PR DESCRIPTION
## Summary

Two improvements to the docs structure: regroup the how-to index by audience, and augment the existing production checklist with operational gates that were missing.

### howto/index.md

The flat 20-row "I want to..." table is now grouped by audience: **Build / Operate / Integrate / Advanced**. Same set of pages, but a reader who knows what they're trying to do can find the right page in one glance instead of scanning a long list.

### howto/gRPC.md — "Calling other services" section

`gRPC.md` previously covered only connection pooling, leaving a reader who is wiring up outbound calls without a clear next step for reliability. Added a "Calling other services" section that collects the three reliability concerns and points each one at its canonical home:

- **Circuit breaking and retries** — `interceptors.SetDefaultExecutor` with failsafe-go → links to `/integrations/#circuit-breaker--resilience`
- **Per-call timeouts** — `context.WithTimeout` on the client side; server-side via `GRPC_SERVER_DEFAULT_TIMEOUT_IN_SECONDS` → links to `/config-reference`
- **Client-side tracing and metrics** — default client interceptors propagate trace ID and emit `grpc_client_*` metrics → links to `/howto/interceptors`

The circuit-breaker content stays in `integrations.md` — that anchor is referenced from FAQ, Packages, and Metrics, and was just patched in commit `25a6ea2` to be stable. A cross-link is the cheaper, less disruptive answer than a content move.

### production.md — checklist augment

The existing in-page Production checklist gets six new gates:

- `terminationGracePeriodSeconds` ≥ `SHUTDOWN_DURATION_IN_SECONDS` (was worded as "shutdown + healthcheck wait duration"; now matches the actual env var)
- Alerts on the four signals every service needs: error-rate spike, p99 latency burn, restart count, OOM kills
- Ship logs to a centralized sink so the trace ID in each line is searchable across pods
- If serving TLS, point `TLS_CERT_PATH` at the cert-manager / Vault symlink so auto-reload picks up rotations
- Set `ADMIN_PORT` if `/metrics`, `/debug/pprof`, and `/swagger` should be on a separate (non-public) port
- Have a rollout plan — canary, blue-green, or progressive — so a bad deploy doesn't take down all replicas at once

### Tests

`tests/content.spec.ts` gets four new assertions:
- `/howto/` shows Build / Operate / Integrate / Advanced headings
- `/howto/gRPC/` contains the new "Calling other services" section and links to circuit-breaker + `GRPC_SERVER_DEFAULT_TIMEOUT_IN_SECONDS`
- `/howto/production/` checklist contains the new gates (p99 latency, OOM, centralized sink, ADMIN_PORT, canary)

This locks the new structure so a future edit can't silently revert the regrouping or drop the new checklist items.

## Test plan
- [ ] `bundle exec jekyll build` succeeds with no broken-link warnings
- [ ] `npx playwright test tests/content.spec.ts` — new assertions pass against a local Jekyll server
- [ ] `npx playwright test tests/links.spec.ts` — existing `/integrations/#circuit-breaker--resilience` anchor still resolves (we did not move the section)
- [ ] Spot-check the rendered site: `/howto/` (grouping), `/howto/gRPC/` (new section), `/howto/production/` (augmented checklist)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized "How To" guides into four categories: Build, Operate, Integrate, and Advanced for improved navigation.
  * Added an intro sentence and re-grouped topics into category-specific "I want to…" tables.
  * Added "Calling other services" guidance on circuit breaking, retries, per-call timeouts, and client-side tracing/metrics (with link to a resilience library).
  * Enhanced production checklist: shutdown timeout requirement, alerting gates, centralized logs, TLS auto-reload guidance, ADMIN_PORT isolation, and mandatory rollout plan.

* **Tests**
  * Added content verification tests to assert the new grouping, gRPC resilience/timeout guidance, links, and production checklist items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->