### PR TITLE
docs: concepts glossary, streaming RPCs, and database/cache/messaging how-tos

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -233,15 +233,7 @@ Use `RegisterHandlerServer` instead of `RegisterHandlerFromEndpoint` in your `In
 
 ## Can I use ColdBrew with gRPC streaming?
 
-Yes. ColdBrew supports both **server streaming** and **bidirectional streaming** RPCs. The stream interceptor chain (response time logging, protovalidate, metrics, panic recovery) is applied automatically.
-
-Define streaming RPCs in your `.proto` file as usual:
-
-```protobuf
-rpc StreamEvents(EventRequest) returns (stream Event) {}
-```
-
-Note: grpc-gateway v2 supports **server streaming** over HTTP by translating gRPC server streams to newline-delimited JSON. Client streaming and bidirectional streaming have limited support — they translate to HTTP but lack true concurrent interleaving over HTTP/1.1. Practical constraints: reverse proxies may buffer streamed responses (requiring `X-Accel-Buffering: no`), and errors in streams are handled via `runtime.WithStreamErrorHandler`. For high-frequency real-time push or bidirectional communication, consider a dedicated WebSocket or SSE endpoint alongside the gateway. See the [grpc-gateway streaming examples](https://github.com/grpc-ecosystem/grpc-gateway/tree/main/examples/internal/proto/examplepb) for details.
+Yes — server-streaming, client-streaming, and bidirectional streaming are all supported, and the stream interceptor chain (response time logging, protovalidate, metrics, panic recovery) is applied automatically. See the [Streaming RPCs how-to](/howto/streaming-rpcs) for handler patterns, deadline propagation, backpressure, and the practical limits when serving the same methods through grpc-gateway over HTTP.
 
 ## How do I run background workers in my service?
 

--- a/Index.md
+++ b/Index.md
@@ -178,6 +178,7 @@ ColdBrew composes proven Go libraries — not replacements:
 ## Next Steps
 
 - **[Getting Started](/getting-started)** — Create your first ColdBrew service
+- **[Concepts](/concepts)** — One-paragraph definitions of the gRPC, observability, and resilience terms ColdBrew builds on
 - **[How-To Guides](/howto)** — Step-by-step guides for common tasks
 - **[Production Deployment](/howto/production)** — Kubernetes, health probes, tracing, and graceful shutdown
 - **[Integrations](/integrations)** — Set up monitoring, tracing, and error tracking

--- a/concepts.md
+++ b/concepts.md
@@ -1,0 +1,81 @@
+---
+layout: default
+title: Concepts
+nav_order: 9
+description: "Glossary of the gRPC, observability, and resilience concepts that ColdBrew builds on. Single-paragraph definitions with links to the deeper guides."
+permalink: /concepts
+---
+# Concepts
+
+A reader who is comfortable with REST but new to the gRPC ecosystem will hit unfamiliar terms in the first few pages — `interceptor`, `gateway`, `vtprotobuf`, `OTLP`, `span`. This page collects them in one place so you can scan a definition and follow the link for depth.
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## gRPC
+
+A high-performance RPC framework from Google that uses HTTP/2 as the transport and Protocol Buffers as the schema/wire format. Methods are typed (request and response messages are defined in `.proto` files) and code is generated for both client and server, so the network call looks like a local function call. ColdBrew is gRPC-first — every service starts as a gRPC server, and the HTTP/JSON surface is generated from the same proto definition. See [grpc.io](https://grpc.io/) for the upstream docs and [APIs how-to](/howto/APIs) for how ColdBrew wires it up.
+
+## gRPC reflection
+
+Server reflection is a gRPC feature that lets a client discover the available methods and message types at runtime, without needing the `.proto` files locally. Tools like [grpcurl], [grpcui], and Postman use reflection to call services interactively. ColdBrew enables it by default; disable it on public-facing services with `DISABLE_GRPC_REFLECTION=true` (see [Production Deployment](/howto/production)).
+
+## grpc-gateway
+
+[grpc-gateway] is a code generator that produces a reverse-proxy HTTP/1.1+JSON server in front of your gRPC service, mapping HTTP routes to gRPC methods using `google.api.http` annotations in the proto. ColdBrew runs the gateway in-process alongside the gRPC server so a single binary speaks both protocols. See [APIs how-to](/howto/APIs) for the routing annotations and [HTTP Gateway Extensions](/howto/gateway-extensions) for adding custom marshalers or middleware.
+
+## Interceptors
+
+Interceptors are gRPC's middleware. They wrap each unary or streaming RPC, running code before and after the handler — logging, tracing, metrics, validation, panic recovery, auth. ColdBrew ships a default chain (response-time logging → trace ID → OpenTelemetry → Prometheus → error notification → New Relic → panic recovery) and exposes hooks to insert your own. See [Interceptors how-to](/howto/interceptors) for the chain order and how to add custom interceptors, and [Authentication](/howto/auth) for an auth-interceptor example.
+
+## vtprotobuf
+
+[vtprotobuf] is a code generator that produces faster Marshal/Unmarshal methods for Protocol Buffer messages — typically 2–3× faster than the reflection-based standard implementation. ColdBrew uses vtprotobuf as its default gRPC codec with automatic fallback to standard protobuf when a message type doesn't have generated VT methods. See [vtprotobuf how-to](/howto/vtproto) for the generator setup.
+
+## Protovalidate
+
+[Protovalidate](https://buf.build/docs/protovalidate/overview) defines validation rules as proto annotations (`buf.validate.field`) and enforces them at runtime. ColdBrew applies validation automatically on both gRPC and HTTP requests, so a malformed payload is rejected with `InvalidArgument` before it reaches your handler. See [Interceptors how-to — Proto Validation](/howto/interceptors#proto-validation).
+
+## OTLP
+
+OpenTelemetry Protocol — the wire format used by [OpenTelemetry] to ship traces, metrics, and logs from your service to a collector or backend. Most modern observability stacks (Jaeger, Tempo, Honeycomb, Datadog, New Relic) accept OTLP, so configuring ColdBrew with `OTLP_ENDPOINT` keeps you portable. See [Tracing how-to](/howto/Tracing) and [Production Deployment — Distributed tracing](/howto/production#distributed-tracing).
+
+## Trace ID
+
+A unique identifier attached to a request that follows it across every service, log line, and span. ColdBrew generates one per request (or accepts one from the `TRACE_HEADER_NAME` HTTP header / proto `trace_id` field), propagates it through context, and adds it to every log line and span automatically. The trace ID is what makes "find every log for this user's failed checkout" tractable in a centralized log sink. See [Tracing how-to](/howto/Tracing) and [Debugging](/howto/Debugging).
+
+## Span
+
+A span represents one unit of work inside a trace — a function call, a database query, an outbound HTTP call. Spans nest inside each other, so a single trace becomes a tree showing where time was spent. ColdBrew exposes three helpers — `tracing.NewInternalSpan`, `tracing.NewDatastoreSpan`, `tracing.NewExternalSpan` — that create the right span type for the operation and put it in `context.Context`. See [Tracing how-to](/howto/Tracing).
+
+## Circuit breaker
+
+A circuit breaker watches the failure rate of an outbound call (a downstream gRPC service, a database, an external API) and "opens" — fast-fails subsequent calls — once failures exceed a threshold, giving the dependency time to recover instead of being hammered. ColdBrew exposes `interceptors.SetDefaultExecutor` so you can plug in any resilience library; [failsafe-go](https://github.com/failsafe-go/failsafe-go) is the recommended one. See [Circuit Breaker / Resilience](/integrations/#circuit-breaker--resilience) for setup and [gRPC how-to — Calling other services](/howto/gRPC#calling-other-services) for context.
+
+## Healthcheck vs readycheck
+
+Two HTTP endpoints with different jobs. `/healthcheck` (liveness) answers *is the process alive?* — if it fails, Kubernetes restarts the pod. `/readycheck` (readiness) answers *can it accept traffic right now?* — if it fails, Kubernetes stops routing traffic to the pod but does not restart it. During graceful shutdown, ColdBrew fails `/readycheck` first, waits the drain period, then exits — so in-flight requests finish without new ones being routed in. See [Production Deployment — Health probes](/howto/production#health-probes) and [Readiness Patterns](/howto/readiness).
+
+## Lifecycle hooks
+
+Optional interfaces a service can implement to run code at well-defined points in startup and shutdown: `CBPreStarter` (before servers listen), `CBPostStarter` (after they listen), `CBPreStopper` / `CBStopper` / `CBPostStopper` (during graceful shutdown), and `CBGracefulStopper.FailCheck` (toggle readiness). Use them to open and drain database pools, register/deregister with service discovery, flush buffers, and so on — without touching `core` itself. See [Shutdown Lifecycle](/howto/signals#service-lifecycle-interfaces) for the full table.
+
+---
+
+## Where to go next
+
+- **[Quick Start](/getting-started)** — Generate a service from the cookiecutter and run it locally.
+- **[How-To Guides](/howto)** — Task-oriented guides grouped by Build / Operate / Integrate / Advanced.
+- **[Architecture](/architecture)** — How the pieces fit together end-to-end.
+
+---
+[grpc-gateway]: https://grpc-ecosystem.github.io/grpc-gateway/
+[grpcurl]: https://github.com/fullstorydev/grpcurl
+[grpcui]: https://github.com/fullstorydev/grpcui
+[OpenTelemetry]: https://opentelemetry.io/
+[vtprotobuf]: https://github.com/planetscale/vtprotobuf

--- a/concepts.md
+++ b/concepts.md
@@ -3,7 +3,7 @@ layout: default
 title: Concepts
 nav_order: 9
 description: "Glossary of the gRPC, observability, and resilience concepts that ColdBrew builds on. Single-paragraph definitions with links to the deeper guides."
-permalink: /concepts
+permalink: /concepts/
 ---
 # Concepts
 

--- a/howto/cache.md
+++ b/howto/cache.md
@@ -45,7 +45,7 @@ make local-stack PROFILES=redis
 make local-stack PROFILES=valkey
 ```
 
-Both profiles expose port `6379`.
+The `redis` profile exposes port `6379`; the `valkey` profile exposes port `6380` so the two can run side by side. See [Local Development](/howto/local-dev#cache) for the full port list.
 
 ### Add the config field
 
@@ -79,7 +79,6 @@ import (
     "time"
 
     "github.com/go-coldbrew/core"
-    "github.com/go-coldbrew/tracing"
     "github.com/redis/go-redis/v9"
 
     "myapp/config" // import path of your service's config package
@@ -198,10 +197,10 @@ Pub/sub-based invalidation across replicas is possible but brittle in a microser
 | Profile | Service | Port |
 |---|---|---|
 | `redis` | Redis 8 | 6379 |
-| `valkey` | Valkey 8 (Redis-compatible) | 6379 |
+| `valkey` | Valkey 8 (Redis-compatible) | 6380 |
 | `memcached` | Memcached | 11211 |
 
-Use one or the other — both bind 6379, so they conflict. See [Local Development](/howto/local-dev) for the full list.
+See [Local Development](/howto/local-dev) for the full profile list.
 
 ## Other caches
 

--- a/howto/cache.md
+++ b/howto/cache.md
@@ -1,0 +1,222 @@
+---
+layout: default
+title: "Cache"
+parent: "How To"
+nav_order: 23
+description: "How to wire a Redis or Valkey cache into a ColdBrew service: client init in PreStart, drain in Stop, cache-aside, and tracing via NewDatastoreSpan"
+---
+# Cache
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+ColdBrew is cache-agnostic — `core` does not import a Redis client and the cookiecutter does not pick one. The same lifecycle pattern as [Database](/howto/database) applies: open the client in `PreStart`, close it in `Stop`, and wrap each call with `tracing.NewDatastoreSpan`.
+
+This page shows the framework pattern with a Redis / Valkey example using [go-redis]. Memcached or any other cache works the same way — swap the client.
+
+## The pattern
+
+```
+PreStart  → open the client, run a Ping
+Stop      → close the client
+NewDatastoreSpan around each call → tracing
+```
+
+Same three interfaces as the database page:
+
+- [`CBPreStarter.PreStart(ctx) error`](https://pkg.go.dev/github.com/go-coldbrew/core#CBPreStarter)
+- [`CBStopper.Stop()`](https://pkg.go.dev/github.com/go-coldbrew/core#CBStopper)
+- [`tracing.NewDatastoreSpan(ctx, datastore, operation, collection)`](https://pkg.go.dev/github.com/go-coldbrew/tracing#NewDatastoreSpan)
+
+## Redis / Valkey with go-redis
+
+[Valkey](https://valkey.io/) is the open-source fork of Redis 7; the wire protocol is identical, so the same client library works against either.
+
+Start the container:
+
+```bash
+make local-stack PROFILES=redis
+# or, identically:
+make local-stack PROFILES=valkey
+```
+
+Both profiles expose port `6379`.
+
+### Add the config field
+
+The cookiecutter `config/` package embeds the framework's `cbConfig.Config` and lets you add fields with `envconfig` tags. Add the cache fields there:
+
+```go
+// config/config.go
+type Config struct {
+    cbConfig.Config
+    auth.AuthConfig
+
+    RedisAddr      string `envconfig:"REDIS_ADDR" required:"true"`
+    RedisPoolSize  int    `envconfig:"REDIS_POOL_SIZE" default:"20"`
+}
+```
+
+Set the value the same way as any other env var:
+
+```bash
+export REDIS_ADDR=localhost:6379
+```
+
+### Wire the client
+
+```go
+package svc
+
+import (
+    "context"
+    "fmt"
+    "time"
+
+    "github.com/go-coldbrew/core"
+    "github.com/go-coldbrew/tracing"
+    "github.com/redis/go-redis/v9"
+
+    "myapp/config" // import path of your service's config package
+)
+
+type Service struct {
+    cache *redis.Client
+}
+
+var (
+    _ core.CBPreStarter = (*Service)(nil)
+    _ core.CBStopper    = (*Service)(nil)
+)
+
+func (s *Service) PreStart(ctx context.Context) error {
+    cfg := config.Get()
+    s.cache = redis.NewClient(&redis.Options{
+        Addr:         cfg.RedisAddr,
+        DialTimeout:  2 * time.Second,
+        ReadTimeout:  500 * time.Millisecond,
+        WriteTimeout: 500 * time.Millisecond,
+        PoolSize:     cfg.RedisPoolSize,
+        MinIdleConns: 2,
+    })
+    if err := s.cache.Ping(ctx).Err(); err != nil {
+        s.cache.Close()
+        return fmt.Errorf("redis ping: %w", err)
+    }
+    return nil
+}
+
+func (s *Service) Stop() {
+    if s.cache != nil {
+        s.cache.Close()
+    }
+}
+```
+
+A failed Ping at startup returns from `PreStart`, which aborts the whole service — exactly the right behaviour when the cache is required. If the cache is **optional** (cache-aside, see below), log the error and proceed; treat cache misses as the empty case.
+
+### Trace each call
+
+Same `NewDatastoreSpan` helper as a database query, with `"redis"` as the datastore:
+
+```go
+func (s *Service) GetSession(ctx context.Context, sid string) (*Session, error) {
+    span, ctx := tracing.NewDatastoreSpan(ctx, "redis", "GET", "session")
+    defer span.End()
+    span.SetTag("session_id", sid)
+
+    raw, err := s.cache.Get(ctx, "session:"+sid).Bytes()
+    if err == redis.Nil {
+        return nil, nil // miss — caller decides what "not found" means
+    }
+    if err != nil {
+        span.SetError(err)
+        return nil, err
+    }
+    var sess Session
+    if err := proto.Unmarshal(raw, &sess); err != nil {
+        span.SetError(err)
+        return nil, err
+    }
+    return &sess, nil
+}
+```
+
+`redis.Nil` is the **expected** "key not found" sentinel — surface it as a miss, not an error, so a cache miss doesn't show up as a failure in your error rate.
+
+## Cache-aside pattern
+
+Cache-aside (lazy population) is the right default for most read-heavy workloads: try the cache first, fall back to the source of truth on a miss, populate the cache on the way back, and tolerate the cache being down.
+
+```go
+func (s *Service) GetUser(ctx context.Context, id int64) (*User, error) {
+    key := fmt.Sprintf("user:%d", id)
+
+    // 1. Try the cache. A failure here is logged and treated as a miss —
+    //    the source of truth still works.
+    if u, err := s.cacheGetUser(ctx, key); err == nil && u != nil {
+        return u, nil
+    } else if err != nil {
+        log.GetLogger(ctx).Warn("cache get failed", "err", err)
+    }
+
+    // 2. Source of truth.
+    u, err := s.dbGetUser(ctx, id)
+    if err != nil || u == nil {
+        return u, err
+    }
+
+    // 3. Populate the cache. Failure to populate is non-fatal.
+    if err := s.cacheSetUser(ctx, key, u); err != nil {
+        log.GetLogger(ctx).Warn("cache set failed", "err", err)
+    }
+    return u, nil
+}
+```
+
+Two principles to keep in mind:
+
+- **Cache failures must not fail the request.** A degraded cache should turn into higher database load, not 5xx errors.
+- **Pick a TTL up front, not by accident.** `SET key value EX 300` (5 minutes) for human-scale data; longer for immutable data; explicit `Del` on writes for anything that *must* invalidate. Avoid relying on memory pressure for eviction — the data you needed evicted first is rarely the data Redis evicts first.
+
+## Invalidation
+
+Cache invalidation is the hard part. Two patterns work in practice for ColdBrew services:
+
+- **Write-through invalidation.** When the source of truth changes, the same handler explicitly `Del`s the cache key. Simple, correct as long as you remember to do it everywhere.
+- **TTL-based.** Set a short TTL and accept stale data within that window. Trivially correct; the trade-off is staleness.
+
+Pub/sub-based invalidation across replicas is possible but brittle in a microservice setting. If you find yourself reaching for it, consider whether your service should own the cache at all, or whether a CDN / fronting service is the better tool.
+
+## Local stack profiles
+
+| Profile | Service | Port |
+|---|---|---|
+| `redis` | Redis 8 | 6379 |
+| `valkey` | Valkey 8 (Redis-compatible) | 6379 |
+| `memcached` | Memcached | 11211 |
+
+Use one or the other — both bind 6379, so they conflict. See [Local Development](/howto/local-dev) for the full list.
+
+## Other caches
+
+- **Memcached** — use [bradfitz/gomemcache] or [rainycape/memcache]. Same `PreStart`/`Stop` pattern; client is a value, no explicit pool. Use `tracing.NewDatastoreSpan(ctx, "memcached", "GET", key)`.
+- **In-process / LRU** — [hashicorp/golang-lru] or stdlib `sync.Map` with eviction. No `PreStart` needed (just construct in your service factory). Tracing is optional since the call doesn't cross process boundaries.
+- **Multi-tier (in-process → Redis)** — wrap two clients behind one interface. Trace each tier separately so you can see the hit ratio at each level.
+
+## Related
+
+- [Database](/howto/database) — Same lifecycle pattern, different client.
+- [Tracing](/howto/Tracing) — How `NewDatastoreSpan` fits into the broader tracing model.
+- [Local Development](/howto/local-dev) — All local-stack profiles.
+- [Shutdown Lifecycle](/howto/signals) — Full lifecycle interface table.
+
+[go-redis]: https://github.com/redis/go-redis
+[bradfitz/gomemcache]: https://github.com/bradfitz/gomemcache
+[rainycape/memcache]: https://github.com/rainycape/memcache
+[hashicorp/golang-lru]: https://github.com/hashicorp/golang-lru

--- a/howto/cache.md
+++ b/howto/cache.md
@@ -21,7 +21,7 @@ This page shows the framework pattern with a Redis / Valkey example using [go-re
 
 ## The pattern
 
-```
+```text
 PreStart  → open the client, run a Ping
 Stop      → close the client
 NewDatastoreSpan around each call → tracing

--- a/howto/cache.md
+++ b/howto/cache.md
@@ -181,7 +181,7 @@ func (s *Service) GetUser(ctx context.Context, id int64) (*User, error) {
 Two principles to keep in mind:
 
 - **Cache failures must not fail the request.** A degraded cache should turn into higher database load, not 5xx errors.
-- **Pick a TTL up front, not by accident.** `SET key value EX 300` (5 minutes) for human-scale data; longer for immutable data; explicit `Del` on writes for anything that *must* invalidate. Avoid relying on memory pressure for eviction — the data you needed evicted first is rarely the data Redis evicts first.
+- **Pick a TTL up front, not by accident.** `SET key value EX 300` (5 minutes) for human-scale data; longer for immutable data; explicit `Del` on writes for anything that *must* invalidate. Avoid relying on memory pressure for eviction — the data you need evicted first is rarely the data Redis evicts first.
 
 ## Invalidation
 

--- a/howto/database.md
+++ b/howto/database.md
@@ -1,0 +1,243 @@
+---
+layout: default
+title: "Database"
+parent: "How To"
+nav_order: 22
+description: "How to wire a database connection pool into a ColdBrew service: pool init in PreStart, drain in Stop, and tracing via NewDatastoreSpan. Library-agnostic with a pgx Postgres example"
+---
+# Database
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+ColdBrew is database-agnostic — `core` does not import a SQL driver and the cookiecutter does not pick one for you. Instead, the framework gives you the lifecycle hooks you need to wire any client cleanly: open the pool when the service starts, close it on shutdown, and trace every query.
+
+This page shows the framework pattern and a runnable Postgres example using [pgx]. The same shape works for MySQL, CockroachDB, AlloyDB, Spanner, or anything else — swap the driver, keep the hooks.
+
+## The pattern
+
+```
+PreStart  → open the pool, run a ping
+Stop      → close the pool
+NewDatastoreSpan around each query → tracing + metrics
+```
+
+Three interfaces from `go-coldbrew/core` carry the work:
+
+- [`CBPreStarter.PreStart(ctx) error`](https://pkg.go.dev/github.com/go-coldbrew/core#CBPreStarter) — runs **before** servers listen. Returning an error aborts startup, so this is the right place to fail-fast if the database is unreachable.
+- [`CBStopper.Stop()`](https://pkg.go.dev/github.com/go-coldbrew/core#CBStopper) — runs after servers stop accepting new RPCs. Close the pool here so in-flight queries drain first.
+- [`tracing.NewDatastoreSpan(ctx, datastore, operation, collection)`](https://pkg.go.dev/github.com/go-coldbrew/tracing#NewDatastoreSpan) — wrap each query so it shows up in the trace tree as a child of the gRPC span.
+
+See [Service lifecycle interfaces](/howto/signals#service-lifecycle-interfaces) for the full hook list.
+
+## Postgres with pgx
+
+Start the database container:
+
+```bash
+make local-stack PROFILES=postgres
+```
+
+The cookiecutter `docker-compose.local.yml` exposes Postgres at `localhost:5432` under the `postgres` profile.
+
+### Add the config field
+
+The cookiecutter ships a `config/` package that embeds the framework's `cbConfig.Config` and lets you add your own fields with `envconfig` tags. Add the database fields there so they're loaded, validated, and accessed the same way as the rest of your config:
+
+```go
+// config/config.go
+type Config struct {
+    cbConfig.Config
+    auth.AuthConfig
+
+    DatabaseURL     string `envconfig:"DATABASE_URL" required:"true"`
+    DBPoolMaxConns  int32  `envconfig:"DB_POOL_MAX_CONNS" default:"20"`
+    DBPoolMinConns  int32  `envconfig:"DB_POOL_MIN_CONNS" default:"2"`
+}
+```
+
+Set the value the same way as any other env var:
+
+```bash
+export DATABASE_URL=postgres://postgres:postgres@localhost:5432/app?sslmode=disable
+```
+
+### Wire the pool
+
+```go
+package svc
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/go-coldbrew/core"
+    "github.com/go-coldbrew/tracing"
+    "github.com/jackc/pgx/v5/pgxpool"
+
+    "myapp/config" // import path of your service's config package
+)
+
+type Service struct {
+    db *pgxpool.Pool
+    // … your other fields
+}
+
+// Compile-time check: Service implements the lifecycle hooks.
+var (
+    _ core.CBPreStarter = (*Service)(nil)
+    _ core.CBStopper    = (*Service)(nil)
+)
+
+func (s *Service) PreStart(ctx context.Context) error {
+    cfg := config.Get()
+
+    poolCfg, err := pgxpool.ParseConfig(cfg.DatabaseURL)
+    if err != nil {
+        return fmt.Errorf("parse DATABASE_URL: %w", err)
+    }
+    poolCfg.MaxConns = cfg.DBPoolMaxConns
+    poolCfg.MinConns = cfg.DBPoolMinConns
+
+    pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+    if err != nil {
+        return fmt.Errorf("connect: %w", err)
+    }
+    if err := pool.Ping(ctx); err != nil {
+        pool.Close()
+        return fmt.Errorf("ping: %w", err)
+    }
+    s.db = pool
+    return nil
+}
+
+func (s *Service) Stop() {
+    if s.db != nil {
+        s.db.Close()
+    }
+}
+```
+
+`PreStart` returning an error aborts startup *before* `/readycheck` ever turns green, so a database outage at boot is loud rather than silent. The corresponding `Stop()` runs after the gRPC server has finished its in-flight RPCs, so in-flight queries get their connections back to the pool before it shuts down.
+
+### Trace every query
+
+Use `tracing.NewDatastoreSpan` so each query becomes a child span of the calling gRPC span. The `datastore` and `operation` arguments become tags in the trace UI and `SetQuery` records the SQL itself:
+
+```go
+import (
+    "context"
+
+    "github.com/go-coldbrew/tracing"
+    "github.com/jackc/pgx/v5"
+)
+
+func (s *Service) GetUser(ctx context.Context, id int64) (*User, error) {
+    span, ctx := tracing.NewDatastoreSpan(ctx, "postgres", "SELECT", "users")
+    defer span.End()
+    span.SetQuery("SELECT id, email FROM users WHERE id = $1")
+
+    row := s.db.QueryRow(ctx, "SELECT id, email FROM users WHERE id = $1", id)
+    var u User
+    if err := row.Scan(&u.ID, &u.Email); err != nil {
+        if err == pgx.ErrNoRows {
+            return nil, nil // not found
+        }
+        span.SetError(err)
+        return nil, err
+    }
+    return &u, nil
+}
+```
+
+The trace ID set by ColdBrew's interceptors is already in `ctx`, so the datastore span attaches to the right trace automatically. `span.SetError(err)` adds the error tag and the next interceptor up the chain will record it on the parent span as well.
+
+### Transactions
+
+Pass the same `ctx` through the whole transaction so all queries land on the same trace and the same context cancellation cancels the whole unit:
+
+```go
+func (s *Service) TransferFunds(ctx context.Context, from, to int64, cents int64) error {
+    span, ctx := tracing.NewDatastoreSpan(ctx, "postgres", "TRANSACTION", "accounts")
+    defer span.End()
+
+    tx, err := s.db.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+    if err != nil {
+        span.SetError(err)
+        return err
+    }
+    defer tx.Rollback(ctx) // safe to call after Commit
+
+    if _, err := tx.Exec(ctx, `UPDATE accounts SET balance = balance - $1 WHERE id = $2`, cents, from); err != nil {
+        span.SetError(err)
+        return err
+    }
+    if _, err := tx.Exec(ctx, `UPDATE accounts SET balance = balance + $1 WHERE id = $2`, cents, to); err != nil {
+        span.SetError(err)
+        return err
+    }
+    if err := tx.Commit(ctx); err != nil {
+        span.SetError(err)
+        return err
+    }
+    return nil
+}
+```
+
+Keep transactions short — each one holds a connection from the pool for its full duration.
+
+## Pool sizing
+
+The right pool size depends on three numbers: how many concurrent RPCs your service handles, how long each query takes, and what the database can sustain.
+
+A reasonable starting point:
+
+- **MaxConns ≈ peak RPC concurrency × queries per RPC**, capped by what the database can serve. A 4-replica service with 100 RPC concurrency each and 1 query per RPC needs ~100 connections per replica — Postgres on commodity hardware tops out around 100–200 concurrent connections, so you may need a connection pooler (PgBouncer, RDS Proxy) in front.
+- **MinConns ≥ 1** so the pool stays warm and the first request after an idle period doesn't pay the connect latency.
+- **Watch `pgxpool.Stat()` (or your driver's equivalent)** — emit `acquired_conns / total_conns` as a Prometheus gauge. If it sits at 100% under load, you're queueing requests on the pool and `MaxConns` is too low.
+
+Don't size the pool from a benchmark on an idle database — concurrency in production is bursty and your tail latency is what matters.
+
+## Other databases
+
+The pattern is identical for any other client. A few pointers:
+
+- **MySQL** — use [go-sql-driver/mysql] with `database/sql`. `sql.Open` returns a pool; configure with `SetMaxOpenConns`, `SetMaxIdleConns`, `SetConnMaxLifetime`.
+- **CockroachDB / AlloyDB** — both speak the Postgres wire protocol; the pgx example above works as-is.
+- **MongoDB** — [mongo-go-driver]. The client *is* the pool; close it in `Stop()`.
+- **Spanner** — [cloud.google.com/go/spanner]. The client manages sessions; close it in `Stop()`.
+- **Object stores (S3, GCS)** — these are external services, not datastores; use `tracing.NewExternalSpan` instead.
+
+For richer query-builder ergonomics on top of any of these, [`sqlc`](https://sqlc.dev/) generates type-safe Go from your SQL and works cleanly with the pattern above.
+
+## Local stack profiles
+
+The cookiecutter `docker-compose.local.yml` ships these database profiles. Start them with `make local-stack PROFILES=<profile>`:
+
+| Profile | Service | Port |
+|---|---|---|
+| `postgres` | Postgres | 5432 |
+| `mysql` | MySQL | 3306 |
+| `cockroachdb` | CockroachDB | 26257 |
+| `mongodb` | MongoDB | 27017 |
+| `alloydb` | AlloyDB Omni | 5432 |
+| `spanner` | Cloud Spanner emulator | 9010 |
+
+See [Local Development](/howto/local-dev) for the full profile list.
+
+## Related
+
+- [Local Development](/howto/local-dev) — All local-stack profiles and how to combine them.
+- [Tracing](/howto/Tracing) — How `NewDatastoreSpan` fits into the broader tracing model.
+- [Shutdown Lifecycle](/howto/signals) — Full lifecycle interface table.
+- [Production Deployment](/howto/production) — Resource limits, alerts, secrets handling.
+
+[pgx]: https://github.com/jackc/pgx
+[go-sql-driver/mysql]: https://github.com/go-sql-driver/mysql
+[mongo-go-driver]: https://github.com/mongodb/mongo-go-driver
+[cloud.google.com/go/spanner]: https://pkg.go.dev/cloud.google.com/go/spanner

--- a/howto/database.md
+++ b/howto/database.md
@@ -21,7 +21,7 @@ This page shows the framework pattern and a runnable Postgres example using [pgx
 
 ## The pattern
 
-```
+```text
 PreStart  → open the pool, run a ping
 Stop      → close the pool
 NewDatastoreSpan around each query → tracing + metrics

--- a/howto/database.md
+++ b/howto/database.md
@@ -43,7 +43,7 @@ Start the database container:
 make local-stack PROFILES=postgres
 ```
 
-The cookiecutter `docker-compose.local.yml` exposes Postgres at `localhost:5432` under the `postgres` profile.
+The cookiecutter `docker-compose.local.yml` exposes Postgres at `localhost:5433` under the `postgres` profile (see [Local Development](/howto/local-dev#databases) for the full port list).
 
 ### Add the config field
 
@@ -64,7 +64,7 @@ type Config struct {
 Set the value the same way as any other env var:
 
 ```bash
-export DATABASE_URL=postgres://postgres:postgres@localhost:5432/app?sslmode=disable
+export DATABASE_URL=postgres://postgres:postgres@localhost:5433/app?sslmode=disable
 ```
 
 ### Wire the pool
@@ -221,11 +221,11 @@ The cookiecutter `docker-compose.local.yml` ships these database profiles. Start
 
 | Profile | Service | Port |
 |---|---|---|
-| `postgres` | Postgres | 5432 |
+| `postgres` | Postgres | 5433 |
 | `mysql` | MySQL | 3306 |
 | `cockroachdb` | CockroachDB | 26257 |
 | `mongodb` | MongoDB | 27017 |
-| `alloydb` | AlloyDB Omni | 5432 |
+| `alloydb` | AlloyDB Omni | 5434 |
 | `spanner` | Cloud Spanner emulator | 9010 |
 
 See [Local Development](/howto/local-dev) for the full profile list.

--- a/howto/index.md
+++ b/howto/index.md
@@ -26,6 +26,10 @@ Designing and writing your service.
 | Run background workers | [Workers](/howto/workers) |
 | Add JWT / API key auth | [Authentication](/howto/auth) |
 | Add custom HTTP marshalers or middleware | [HTTP Gateway Extensions](/howto/gateway-extensions) |
+| Use server, client, or bidi streaming | [Streaming RPCs](/howto/streaming-rpcs) |
+| Wire a database connection pool | [Database](/howto/database) |
+| Cache reads with Redis or Valkey | [Cache](/howto/cache) |
+| Consume Kafka or NATS messages | [Messaging](/howto/messaging) |
 
 ## Operate
 

--- a/howto/local-dev.md
+++ b/howto/local-dev.md
@@ -38,6 +38,8 @@ make local-stack PROFILES="postgres kafka nats"
 
 ### Databases
 
+See [Database](/howto/database) for the lifecycle pattern (open the pool in `PreStart`, close in `Stop`) and a runnable Postgres example.
+
 | Profile | Image | Host Port | Notes |
 |---------|-------|-----------|-------|
 | `postgres` | `postgres:18-alpine` | 5433 | Health check: `pg_isready` |
@@ -48,6 +50,8 @@ make local-stack PROFILES="postgres kafka nats"
 
 ### Cache
 
+See [Cache](/howto/cache) for the wiring pattern, cache-aside, and a Redis / Valkey example.
+
 | Profile | Image | Host Port | Notes |
 |---------|-------|-----------|-------|
 | `redis` | `redis:8-alpine` | 6379 | Health check: `redis-cli ping` |
@@ -55,6 +59,8 @@ make local-stack PROFILES="postgres kafka nats"
 | `memcached` | `memcached:alpine` | 11211 | |
 
 ### Messaging
+
+See [Messaging](/howto/messaging) for consumer patterns via the workers package and Kafka / NATS examples with graceful drain.
 
 | Profile | Image | Host Port | Notes |
 |---------|-------|-----------|-------|

--- a/howto/messaging.md
+++ b/howto/messaging.md
@@ -1,0 +1,301 @@
+---
+layout: default
+title: "Messaging"
+parent: "How To"
+nav_order: 24
+description: "How to run Kafka or NATS consumers in a ColdBrew service via workers.Worker, with graceful drain on shutdown and built-in tracing"
+---
+# Messaging
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+ColdBrew is broker-agnostic — `core` does not import a Kafka or NATS client. Consumers run as long-lived workers via the [workers package](/howto/workers), so the framework already handles startup, panic recovery, restart, metrics, and the graceful drain on shutdown. You bring the client; ColdBrew runs it.
+
+This page shows the framework pattern and Kafka and NATS examples. The same shape works for any subscription-style broker — Pub/Sub, RabbitMQ, SQS — swap the client.
+
+## The pattern
+
+A messaging consumer is a long-running worker:
+
+```
+CBWorkerProvider.Workers() returns one *workers.Worker per subscription.
+Each worker:
+  - opens its broker client
+  - reads in a loop, handling each message
+  - returns when ctx.Done() fires
+  - returns ctx.Err() so core treats it as a clean shutdown
+```
+
+Two interfaces from `go-coldbrew/core` and one helper from `go-coldbrew/workers` carry the work:
+
+- [`CBWorkerProvider.Workers() []*workers.Worker`](https://pkg.go.dev/github.com/go-coldbrew/core#CBWorkerProvider) — implement this on your service to register workers.
+- [`workers.NewWorker(name).HandlerFunc(fn)`](https://pkg.go.dev/github.com/go-coldbrew/workers#NewWorker) — build a worker from a function with signature `func(ctx context.Context, info *workers.WorkerInfo) error`.
+- [`CBPreStopper.PreStop(ctx)`](https://pkg.go.dev/github.com/go-coldbrew/core#CBPreStopper) — optional; runs *before* the worker context is cancelled. Use it to deregister from the broker or pause new work without dropping in-flight messages.
+
+When core shuts down, it cancels the worker context (step 4 in the [shutdown sequence](/howto/signals#graceful-shutdown)). Your handler sees `ctx.Done()` close, finishes the in-flight message, and returns `ctx.Err()`. Core waits for that return before stopping the gRPC server, so a slow consumer drains cleanly.
+
+See [Workers how-to](/howto/workers) for the full worker API (middleware, jitter, restart-on-fail, child workers, metrics).
+
+## Kafka with kafka-go
+
+Start the Kafka container:
+
+```bash
+make local-stack PROFILES=kafka
+```
+
+The cookiecutter `docker-compose.local.yml` exposes Kafka at `localhost:9092` under the `kafka` profile.
+
+Add the broker fields to your `config/config.go` so they're loaded the same way as the rest of your config:
+
+```go
+// config/config.go
+type Config struct {
+    cbConfig.Config
+    auth.AuthConfig
+
+    KafkaBrokers []string `envconfig:"KAFKA_BROKERS" required:"true"`
+    KafkaTopic   string   `envconfig:"KAFKA_TOPIC" required:"true"`
+    KafkaGroupID string   `envconfig:"KAFKA_GROUP_ID" required:"true"`
+}
+```
+
+Then set the values like any other env var:
+
+```bash
+export KAFKA_BROKERS=localhost:9092
+export KAFKA_TOPIC=events
+export KAFKA_GROUP_ID=my-service
+```
+
+[segmentio/kafka-go] is a pure-Go client with a context-aware reader API that fits the worker pattern naturally:
+
+```go
+package svc
+
+import (
+    "context"
+    "errors"
+    "io"
+    "time"
+
+    "github.com/go-coldbrew/core"
+    "github.com/go-coldbrew/log"
+    "github.com/go-coldbrew/tracing"
+    "github.com/go-coldbrew/workers"
+    "github.com/segmentio/kafka-go"
+
+    "myapp/config" // import path of your service's config package
+)
+
+type Service struct {
+    // … your other fields
+}
+
+var _ core.CBWorkerProvider = (*Service)(nil)
+
+func (s *Service) Workers() []*workers.Worker {
+    return []*workers.Worker{
+        workers.NewWorker("kafka-events").HandlerFunc(s.consumeEvents),
+    }
+}
+
+func (s *Service) consumeEvents(ctx context.Context, info *workers.WorkerInfo) error {
+    cfg := config.Get()
+    reader := kafka.NewReader(kafka.ReaderConfig{
+        Brokers:        cfg.KafkaBrokers,
+        Topic:          cfg.KafkaTopic,
+        GroupID:        cfg.KafkaGroupID,
+        MinBytes:       1,
+        MaxBytes:       10 << 20, // 10 MB
+        CommitInterval: time.Second,
+    })
+    defer reader.Close()
+
+    for {
+        msg, err := reader.ReadMessage(ctx)
+        if err != nil {
+            // Context cancellation is the expected shutdown signal.
+            if errors.Is(err, context.Canceled) || errors.Is(err, io.EOF) {
+                return ctx.Err()
+            }
+            log.GetLogger(ctx).Error("kafka read", "err", err)
+            return err // worker will restart by default
+        }
+        if err := s.handleEvent(ctx, msg); err != nil {
+            // Decide: log-and-continue (at-least-once with poison-pill risk),
+            // or return the error to trigger a restart.
+            log.GetLogger(ctx).Error("handle event", "err", err, "offset", msg.Offset)
+        }
+    }
+}
+
+func (s *Service) handleEvent(ctx context.Context, msg kafka.Message) error {
+    span, ctx := tracing.NewInternalSpan(ctx, "handleEvent")
+    defer span.End()
+    span.SetTag("kafka.topic", msg.Topic)
+    span.SetTag("kafka.partition", msg.Partition)
+    span.SetTag("kafka.offset", msg.Offset)
+
+    // … your business logic on msg.Value
+    return nil
+}
+```
+
+The shape of the loop is the important part:
+
+- **`ReadMessage(ctx)` is the cancellation point.** When core cancels `ctx`, `ReadMessage` returns immediately and the handler returns `ctx.Err()` — a clean drain.
+- **Handler errors are a policy choice.** Returning the error restarts the worker (and re-reads the same offset, since `kafka-go` only commits successful work). Logging and continuing skips the message but keeps the consumer alive — fine for non-critical events, dangerous for anything you must process.
+- **Per-message tracing uses `NewInternalSpan`.** The span has no parent gRPC trace, so it starts a fresh trace per message; tag the topic/partition/offset so you can correlate with broker-side logs.
+
+## NATS with nats.go
+
+Start the NATS container:
+
+```bash
+make local-stack PROFILES=nats
+```
+
+NATS exposes port `4222` under the `nats` profile. Add the connection field to `config/config.go`:
+
+```go
+// config/config.go
+type Config struct {
+    cbConfig.Config
+    auth.AuthConfig
+
+    NATSURL     string `envconfig:"NATS_URL" required:"true"`
+    NATSSubject string `envconfig:"NATS_SUBJECT" required:"true"`
+    NATSQueue   string `envconfig:"NATS_QUEUE" required:"true"`
+}
+```
+
+Then export the values:
+
+```bash
+export NATS_URL=nats://localhost:4222
+export NATS_SUBJECT=orders.created
+export NATS_QUEUE=my-service
+```
+
+The official client [nats-io/nats.go] uses a callback-style subscription, which is a slightly different worker shape — the worker exists to keep the subscription alive and to drain on shutdown, while the callback runs each message:
+
+```go
+package svc
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/go-coldbrew/core"
+    "github.com/go-coldbrew/log"
+    "github.com/go-coldbrew/tracing"
+    "github.com/go-coldbrew/workers"
+    "github.com/nats-io/nats.go"
+
+    "myapp/config" // import path of your service's config package
+)
+
+type Service struct {
+    nc *nats.Conn
+}
+
+var (
+    _ core.CBWorkerProvider = (*Service)(nil)
+    _ core.CBPreStarter     = (*Service)(nil)
+    _ core.CBStopper        = (*Service)(nil)
+)
+
+func (s *Service) PreStart(ctx context.Context) error {
+    nc, err := nats.Connect(config.Get().NATSURL)
+    if err != nil {
+        return fmt.Errorf("nats connect: %w", err)
+    }
+    s.nc = nc
+    return nil
+}
+
+func (s *Service) Stop() {
+    if s.nc != nil {
+        // Drain blocks until in-flight callbacks finish.
+        _ = s.nc.Drain()
+    }
+}
+
+func (s *Service) Workers() []*workers.Worker {
+    return []*workers.Worker{
+        workers.NewWorker("nats-orders").HandlerFunc(s.consumeOrders),
+    }
+}
+
+func (s *Service) consumeOrders(ctx context.Context, info *workers.WorkerInfo) error {
+    cfg := config.Get()
+    sub, err := s.nc.QueueSubscribe(cfg.NATSSubject, cfg.NATSQueue, func(m *nats.Msg) {
+        s.handleOrder(ctx, m)
+    })
+    if err != nil {
+        return err
+    }
+    defer sub.Unsubscribe()
+
+    <-ctx.Done() // block until shutdown
+    return ctx.Err()
+}
+
+func (s *Service) handleOrder(ctx context.Context, m *nats.Msg) {
+    span, ctx := tracing.NewInternalSpan(ctx, "handleOrder")
+    defer span.End()
+    span.SetTag("nats.subject", m.Subject)
+
+    // … your business logic on m.Data
+}
+```
+
+Notice the split:
+
+- **`PreStart` opens the connection** so the service fails fast if NATS is unreachable.
+- **`Stop()` calls `Drain()`**, which stops accepting new messages but waits for in-flight callbacks to finish — this is the NATS equivalent of "graceful shutdown."
+- **The worker exists to hold the subscription open** until `ctx.Done()`, then unsubscribes. `Drain()` in `Stop()` then handles the in-flight callbacks.
+
+## Tracing across the broker boundary
+
+The two examples above start a fresh trace per message because the publisher and consumer are usually separate services and broker messages don't carry trace context by default. You have two options for correlating producer and consumer:
+
+- **Inject the trace ID into message metadata.** Kafka has headers; NATS has `nats.Msg.Header`; both let you propagate a `trace-id` you can read on the consumer side and use as the parent span. Most tracing backends (OTLP-compatible, New Relic) understand this if you use the standard W3C `traceparent` header name.
+- **Treat consumer and producer as separate traces, link by domain ID.** Tag both spans with the same business identifier (order ID, user ID) and rely on log correlation. Simpler, less precise.
+
+For most internal services, the second option is good enough; reach for trace-context propagation when you need to debug a specific cross-broker latency problem.
+
+## Shutdown and at-least-once delivery
+
+The default worker behaviour gives you **at-least-once** delivery: a message that is read but not yet acknowledged when shutdown begins will be redelivered on the next consumer (Kafka commits offsets, NATS replays unacked messages on a JetStream consumer, etc.).
+
+Two operational consequences:
+
+- **Make handlers idempotent.** A duplicate message during a rolling deploy is normal, not a bug.
+- **Tune `SHUTDOWN_DURATION_IN_SECONDS` to allow drain.** The default is 15s. If your handler's tail latency is longer than that, increase the shutdown duration or the per-message work won't finish before SIGKILL. See [Production Deployment — Graceful shutdown tuning](/howto/production#graceful-shutdown-tuning).
+
+## Local stack profiles
+
+| Profile | Service | Port |
+|---|---|---|
+| `kafka` | Kafka (KRaft, no ZK) | 9092 |
+| `nats` | NATS | 4222 |
+
+See [Local Development](/howto/local-dev) for the full list, including `pubsub` (Google Pub/Sub emulator) which follows the same worker pattern.
+
+## Related
+
+- [Workers](/howto/workers) — Full worker API: middleware, jitter, restart, metrics, child workers.
+- [Readiness Patterns](/howto/readiness) — Combining workers with `/readycheck` so the service only reports ready once consumers are subscribed.
+- [Tracing](/howto/Tracing) — Internal spans and trace propagation.
+- [Shutdown Lifecycle](/howto/signals) — Where worker drain fits in the broader shutdown sequence.
+
+[segmentio/kafka-go]: https://github.com/segmentio/kafka-go
+[nats-io/nats.go]: https://github.com/nats-io/nats.go

--- a/howto/messaging.md
+++ b/howto/messaging.md
@@ -23,7 +23,7 @@ This page shows the framework pattern and Kafka and NATS examples. The same shap
 
 A messaging consumer is a long-running worker:
 
-```
+```text
 CBWorkerProvider.Workers() returns one *workers.Worker per subscription.
 Each worker:
   - opens its broker client
@@ -246,15 +246,17 @@ func (s *Service) PreStart(ctx context.Context) error {
     if err != nil {
         return fmt.Errorf("nats connect: %w", err)
     }
-    s.nc = nc
 
     // Buffered channel = explicit backpressure knob. Once full, NATS will
     // start dropping messages for the subscription unless you've enabled
     // JetStream flow control on the broker side.
-    s.msgCh = make(chan *nats.Msg, 64)
-    if _, err := nc.ChanQueueSubscribe(cfg.NATSSubject, cfg.NATSQueue, s.msgCh); err != nil {
+    msgCh := make(chan *nats.Msg, 64)
+    if _, err := nc.ChanQueueSubscribe(cfg.NATSSubject, cfg.NATSQueue, msgCh); err != nil {
+        nc.Close() // don't leak the connection if the subscription failed
         return fmt.Errorf("nats subscribe: %w", err)
     }
+    s.nc = nc
+    s.msgCh = msgCh
     return nil
 }
 

--- a/howto/messaging.md
+++ b/howto/messaging.md
@@ -231,12 +231,14 @@ import (
 
 type Service struct {
     nc    *nats.Conn
+    sub   *nats.Subscription
     msgCh chan *nats.Msg
 }
 
 var (
     _ core.CBWorkerProvider = (*Service)(nil)
     _ core.CBPreStarter     = (*Service)(nil)
+    _ core.CBPreStopper     = (*Service)(nil)
     _ core.CBStopper        = (*Service)(nil)
 )
 
@@ -251,19 +253,29 @@ func (s *Service) PreStart(ctx context.Context) error {
     // start dropping messages for the subscription unless you've enabled
     // JetStream flow control on the broker side.
     msgCh := make(chan *nats.Msg, 64)
-    if _, err := nc.ChanQueueSubscribe(cfg.NATSSubject, cfg.NATSQueue, msgCh); err != nil {
+    sub, err := nc.ChanQueueSubscribe(cfg.NATSSubject, cfg.NATSQueue, msgCh)
+    if err != nil {
         nc.Close() // don't leak the connection if the subscription failed
         return fmt.Errorf("nats subscribe: %w", err)
     }
     s.nc = nc
+    s.sub = sub
     s.msgCh = msgCh
+    return nil
+}
+
+// PreStop runs *before* core cancels the worker context, so the consumer
+// is still reading from msgCh while we drain the subscription.
+func (s *Service) PreStop(ctx context.Context) error {
+    if s.sub != nil {
+        return s.sub.Drain()
+    }
     return nil
 }
 
 func (s *Service) Stop() {
     if s.nc != nil {
-        // Drain stops accepting new messages and waits for the channel to empty.
-        _ = s.nc.Drain()
+        s.nc.Close()
     }
 }
 
@@ -290,7 +302,7 @@ Notice the split:
 - **`PreStart` opens the connection and registers the subscription.** Messages start landing in `s.msgCh` immediately; the worker hasn't started yet, but the buffered channel absorbs them.
 - **`workers.ChannelWorker(s.msgCh, s.handleOrder)`** is the whole consumer loop — it reads the next message, calls your handler, returns the handler's error to restart the worker, and exits cleanly when `ctx.Done()` fires.
 - **Consumption is independent of the wiring.** `handleOrder` takes only `(ctx, info, *nats.Msg)` and knows nothing about subscriptions, channels, or NATS lifecycle — you can unit-test it with a hand-built `*nats.Msg`, and the same handler shape would work behind any source that produces a `chan T` (an internal pipeline, a generated mock, a different broker). The channel is the seam.
-- **`Stop()` calls `Drain()`**, which stops new messages and lets the channel empty before the connection closes.
+- **Drain order matters.** `PreStop` runs at [shutdown step 1](/howto/signals#graceful-shutdown), *before* the worker context is cancelled at step 4 — so calling `s.sub.Drain()` here stops the broker from sending new messages while the worker is still consuming, and the buffered channel empties during the drain wait. By the time `Stop()` runs at step 9, the worker has exited cleanly and we just need to close the connection. Calling `Drain()` from `Stop()` instead would block on a channel no one is reading from.
 
 For batch processing, swap `workers.ChannelWorker` for [`workers.BatchChannelWorker(ch, maxSize, maxDelay, fn)`](https://pkg.go.dev/github.com/go-coldbrew/workers#BatchChannelWorker) — same shape, but flushes batches by size or time, whichever comes first.
 

--- a/howto/messaging.md
+++ b/howto/messaging.md
@@ -42,7 +42,7 @@ When core shuts down, it cancels the worker context (step 4 in the [shutdown seq
 
 See [Workers how-to](/howto/workers) for the full worker API (middleware, jitter, restart-on-fail, child workers, metrics).
 
-## Kafka with kafka-go
+## Kafka with sarama
 
 Start the Kafka container:
 
@@ -74,7 +74,7 @@ export KAFKA_TOPIC=events
 export KAFKA_GROUP_ID=my-service
 ```
 
-[segmentio/kafka-go] is a pure-Go client with a context-aware reader API that fits the worker pattern naturally:
+[IBM/sarama] is the most widely deployed Kafka client for Go. Its consumer-group API requires a small `ConsumerGroupHandler` adapter but gives you at-least-once semantics by default — `MarkMessage` only after the handler succeeds:
 
 ```go
 package svc
@@ -82,14 +82,13 @@ package svc
 import (
     "context"
     "errors"
-    "io"
-    "time"
+    "fmt"
 
+    "github.com/IBM/sarama"
     "github.com/go-coldbrew/core"
     "github.com/go-coldbrew/log"
     "github.com/go-coldbrew/tracing"
     "github.com/go-coldbrew/workers"
-    "github.com/segmentio/kafka-go"
 
     "myapp/config" // import path of your service's config package
 )
@@ -108,35 +107,63 @@ func (s *Service) Workers() []*workers.Worker {
 
 func (s *Service) consumeEvents(ctx context.Context, info *workers.WorkerInfo) error {
     cfg := config.Get()
-    reader := kafka.NewReader(kafka.ReaderConfig{
-        Brokers:        cfg.KafkaBrokers,
-        Topic:          cfg.KafkaTopic,
-        GroupID:        cfg.KafkaGroupID,
-        MinBytes:       1,
-        MaxBytes:       10 << 20, // 10 MB
-        CommitInterval: time.Second,
-    })
-    defer reader.Close()
+    saramaCfg := sarama.NewConfig()
+    saramaCfg.Version = sarama.V3_6_0_0
+    // Auto-commit is on by default with a 1s interval. Marked offsets are
+    // committed at most ~1s after MarkMessage; a crash inside that window
+    // replays at most ~1s of work. For strictest at-least-once, set
+    // saramaCfg.Consumer.Offsets.AutoCommit.Enable = false and call
+    // sess.Commit() after MarkMessage.
 
+    group, err := sarama.NewConsumerGroup(cfg.KafkaBrokers, cfg.KafkaGroupID, saramaCfg)
+    if err != nil {
+        return fmt.Errorf("kafka consumer group: %w", err)
+    }
+    defer group.Close()
+
+    handler := &consumerGroupHandler{svc: s}
     for {
-        msg, err := reader.ReadMessage(ctx)
-        if err != nil {
-            // Context cancellation is the expected shutdown signal.
-            if errors.Is(err, context.Canceled) || errors.Is(err, io.EOF) {
+        // Consume blocks until the session ends (rebalance, error, or ctx cancellation),
+        // then we re-enter so the group rejoins after a rebalance.
+        if err := group.Consume(ctx, []string{cfg.KafkaTopic}, handler); err != nil {
+            if errors.Is(err, sarama.ErrClosedConsumerGroup) {
                 return ctx.Err()
             }
-            log.GetLogger(ctx).Error("kafka read", "err", err)
-            return err // worker will restart by default
+            log.GetLogger(ctx).Error("kafka consume", "err", err)
+            return err
         }
-        if err := s.handleEvent(ctx, msg); err != nil {
-            // Decide: log-and-continue (at-least-once with poison-pill risk),
-            // or return the error to trigger a restart.
-            log.GetLogger(ctx).Error("handle event", "err", err, "offset", msg.Offset)
+        if ctx.Err() != nil {
+            return ctx.Err()
         }
     }
 }
 
-func (s *Service) handleEvent(ctx context.Context, msg kafka.Message) error {
+type consumerGroupHandler struct {
+    svc *Service
+}
+
+func (h *consumerGroupHandler) Setup(sarama.ConsumerGroupSession) error   { return nil }
+func (h *consumerGroupHandler) Cleanup(sarama.ConsumerGroupSession) error { return nil }
+
+func (h *consumerGroupHandler) ConsumeClaim(sess sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
+    for {
+        select {
+        case <-sess.Context().Done():
+            return nil
+        case msg, ok := <-claim.Messages():
+            if !ok {
+                return nil // partition revoked or claim closed
+            }
+            if err := h.svc.handleEvent(sess.Context(), msg); err != nil {
+                log.GetLogger(sess.Context()).Error("handle event", "err", err, "offset", msg.Offset)
+                return err // session ends; group rebalances; message replays
+            }
+            sess.MarkMessage(msg, "")
+        }
+    }
+}
+
+func (s *Service) handleEvent(ctx context.Context, msg *sarama.ConsumerMessage) error {
     span, ctx := tracing.NewInternalSpan(ctx, "handleEvent")
     defer span.End()
     span.SetTag("kafka.topic", msg.Topic)
@@ -150,8 +177,9 @@ func (s *Service) handleEvent(ctx context.Context, msg kafka.Message) error {
 
 The shape of the loop is the important part:
 
-- **`ReadMessage(ctx)` is the cancellation point.** When core cancels `ctx`, `ReadMessage` returns immediately and the handler returns `ctx.Err()` — a clean drain.
-- **Handler errors are a policy choice.** Returning the error restarts the worker (and re-reads the same offset, since `kafka-go` only commits successful work). Logging and continuing skips the message but keeps the consumer alive — fine for non-critical events, dangerous for anything you must process.
+- **Mark only after success is what makes it at-least-once.** `MarkMessage` advances the in-memory offset for the partition; the consumer group flushes marked offsets on the auto-commit interval (default 1s). Returning before `MarkMessage` means the message replays after the next rebalance — exactly the behaviour you want when a handler errors.
+- **`sess.Context().Done()` is the cancellation point.** When core cancels the worker context, `group.Close()` ends the session and `sess.Context()` fires `Done()`; `ConsumeClaim` returns nil for a clean drain.
+- **The outer `for { Consume; ... }` loop handles rebalances.** Each `Consume` call holds one session; rejoining the group requires re-entering. A non-rebalance error breaks out and returns the error so the worker restarts.
 - **Per-message tracing uses `NewInternalSpan`.** The span has no parent gRPC trace, so it starts a fresh trace per message; tag the topic/partition/offset so you can correlate with broker-side logs.
 
 ## NATS with nats.go
@@ -184,7 +212,7 @@ export NATS_SUBJECT=orders.created
 export NATS_QUEUE=my-service
 ```
 
-The official client [nats-io/nats.go] uses a callback-style subscription, which is a slightly different worker shape — the worker exists to keep the subscription alive and to drain on shutdown, while the callback runs each message:
+The official client [nats-io/nats.go] supports both callback-style subscriptions (`QueueSubscribe`) and channel-style (`ChanQueueSubscribe`). Channel-style fits the workers package directly via [`workers.ChannelWorker`](https://pkg.go.dev/github.com/go-coldbrew/workers#ChannelWorker), which already implements the `select { ctx.Done() / msgCh }` loop, error propagation, and clean drain on cancellation:
 
 ```go
 package svc
@@ -194,7 +222,6 @@ import (
     "fmt"
 
     "github.com/go-coldbrew/core"
-    "github.com/go-coldbrew/log"
     "github.com/go-coldbrew/tracing"
     "github.com/go-coldbrew/workers"
     "github.com/nats-io/nats.go"
@@ -203,7 +230,8 @@ import (
 )
 
 type Service struct {
-    nc *nats.Conn
+    nc    *nats.Conn
+    msgCh chan *nats.Msg
 }
 
 var (
@@ -213,55 +241,56 @@ var (
 )
 
 func (s *Service) PreStart(ctx context.Context) error {
-    nc, err := nats.Connect(config.Get().NATSURL)
+    cfg := config.Get()
+    nc, err := nats.Connect(cfg.NATSURL)
     if err != nil {
         return fmt.Errorf("nats connect: %w", err)
     }
     s.nc = nc
+
+    // Buffered channel = explicit backpressure knob. Once full, NATS will
+    // start dropping messages for the subscription unless you've enabled
+    // JetStream flow control on the broker side.
+    s.msgCh = make(chan *nats.Msg, 64)
+    if _, err := nc.ChanQueueSubscribe(cfg.NATSSubject, cfg.NATSQueue, s.msgCh); err != nil {
+        return fmt.Errorf("nats subscribe: %w", err)
+    }
     return nil
 }
 
 func (s *Service) Stop() {
     if s.nc != nil {
-        // Drain blocks until in-flight callbacks finish.
+        // Drain stops accepting new messages and waits for the channel to empty.
         _ = s.nc.Drain()
     }
 }
 
 func (s *Service) Workers() []*workers.Worker {
     return []*workers.Worker{
-        workers.NewWorker("nats-orders").HandlerFunc(s.consumeOrders),
+        workers.NewWorker("nats-orders").HandlerFunc(
+            workers.ChannelWorker(s.msgCh, s.handleOrder),
+        ),
     }
 }
 
-func (s *Service) consumeOrders(ctx context.Context, info *workers.WorkerInfo) error {
-    cfg := config.Get()
-    sub, err := s.nc.QueueSubscribe(cfg.NATSSubject, cfg.NATSQueue, func(m *nats.Msg) {
-        s.handleOrder(ctx, m)
-    })
-    if err != nil {
-        return err
-    }
-    defer sub.Unsubscribe()
-
-    <-ctx.Done() // block until shutdown
-    return ctx.Err()
-}
-
-func (s *Service) handleOrder(ctx context.Context, m *nats.Msg) {
+func (s *Service) handleOrder(ctx context.Context, info *workers.WorkerInfo, m *nats.Msg) error {
     span, ctx := tracing.NewInternalSpan(ctx, "handleOrder")
     defer span.End()
     span.SetTag("nats.subject", m.Subject)
 
     // … your business logic on m.Data
+    return nil
 }
 ```
 
 Notice the split:
 
-- **`PreStart` opens the connection** so the service fails fast if NATS is unreachable.
-- **`Stop()` calls `Drain()`**, which stops accepting new messages but waits for in-flight callbacks to finish — this is the NATS equivalent of "graceful shutdown."
-- **The worker exists to hold the subscription open** until `ctx.Done()`, then unsubscribes. `Drain()` in `Stop()` then handles the in-flight callbacks.
+- **`PreStart` opens the connection and registers the subscription.** Messages start landing in `s.msgCh` immediately; the worker hasn't started yet, but the buffered channel absorbs them.
+- **`workers.ChannelWorker(s.msgCh, s.handleOrder)`** is the whole consumer loop — it reads the next message, calls your handler, returns the handler's error to restart the worker, and exits cleanly when `ctx.Done()` fires.
+- **Consumption is independent of the wiring.** `handleOrder` takes only `(ctx, info, *nats.Msg)` and knows nothing about subscriptions, channels, or NATS lifecycle — you can unit-test it with a hand-built `*nats.Msg`, and the same handler shape would work behind any source that produces a `chan T` (an internal pipeline, a generated mock, a different broker). The channel is the seam.
+- **`Stop()` calls `Drain()`**, which stops new messages and lets the channel empty before the connection closes.
+
+For batch processing, swap `workers.ChannelWorker` for [`workers.BatchChannelWorker(ch, maxSize, maxDelay, fn)`](https://pkg.go.dev/github.com/go-coldbrew/workers#BatchChannelWorker) — same shape, but flushes batches by size or time, whichever comes first.
 
 ## Tracing across the broker boundary
 
@@ -297,5 +326,5 @@ See [Local Development](/howto/local-dev) for the full list, including `pubsub` 
 - [Tracing](/howto/Tracing) — Internal spans and trace propagation.
 - [Shutdown Lifecycle](/howto/signals) — Where worker drain fits in the broader shutdown sequence.
 
-[segmentio/kafka-go]: https://github.com/segmentio/kafka-go
+[IBM/sarama]: https://github.com/IBM/sarama
 [nats-io/nats.go]: https://github.com/nats-io/nats.go

--- a/howto/signals.md
+++ b/howto/signals.md
@@ -32,7 +32,7 @@ When the application receives a signal, ColdBrew executes a multi-step shutdown 
 1. **`PreStop(ctx)`** on services implementing [CBPreStopper] — deregister from service discovery, flush buffers
 2. **`FailCheck(true)`** on services implementing [CBGracefulStopper] — `/readycheck` starts returning failure
 3. **Wait** `GRPC_GRACEFUL_DURATION_IN_SECONDS` (default: 7s) for the load balancer to stop sending traffic
-4. **Stop workers** — cancel worker context, wait for workers to exit
+4. **Stop workers** — cancel worker context, wait for workers to exit (see [Messaging](/howto/messaging) for the consumer-drain pattern)
 5. **Shutdown admin server** if configured (`ADMIN_PORT`)
 6. **Shutdown HTTP server** — stop accepting new HTTP requests
 7. **`GracefulStop()` gRPC server** — finish in-flight RPCs, reject new ones

--- a/howto/streaming-rpcs.md
+++ b/howto/streaming-rpcs.md
@@ -133,7 +133,13 @@ func (s *ChatService) Chat(stream pb.Chat_ChatServer) error {
                 return nil
             }
             return err
-        case msg := <-incoming:
+        case msg, ok := <-incoming:
+            if !ok {
+                // Reader closed the channel — wait for the error from errCh
+                // on the next iteration so EOF and read errors propagate.
+                incoming = nil
+                continue
+            }
             reply := s.handle(msg)
             if err := stream.Send(reply); err != nil {
                 return err

--- a/howto/streaming-rpcs.md
+++ b/howto/streaming-rpcs.md
@@ -102,6 +102,8 @@ func (s *EventsService) UploadSamples(stream pb.Events_UploadSamplesServer) erro
 The simplest pattern is to read in a goroutine and write from the main goroutine (or vice versa). Use the stream's context to coordinate cancellation:
 
 ```go
+import "io"
+
 func (s *ChatService) Chat(stream pb.Chat_ChatServer) error {
     ctx := stream.Context()
 

--- a/howto/streaming-rpcs.md
+++ b/howto/streaming-rpcs.md
@@ -1,0 +1,196 @@
+---
+layout: default
+title: "Streaming RPCs"
+parent: "How To"
+nav_order: 21
+description: "Server, client, and bidirectional streaming RPCs in ColdBrew — proto definitions, handler patterns, deadline propagation, backpressure, and grpc-gateway HTTP-streaming limits"
+---
+# Streaming RPCs
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+ColdBrew supports all four gRPC method shapes: unary, server-streaming, client-streaming, and bidirectional streaming. The default stream interceptor chain (response-time logging, protovalidate, metrics, panic recovery) is applied automatically — you don't need to opt in.
+
+This page covers when to use each shape, the handler patterns, and the practical limits when serving the same methods through grpc-gateway over HTTP.
+
+## When to use streaming
+
+| Shape | When to use it | When **not** to |
+|---|---|---|
+| **Server-streaming** | Pushing a sequence of items the server already knows about — paginated results without round-trips, log tailing, change feeds, real-time updates. | One-shot responses (use unary). |
+| **Client-streaming** | Uploading a large payload in chunks, accumulating samples, batch ingest. | When the server needs to acknowledge each item — you'd want bidi. |
+| **Bidirectional** | Long-lived sessions where both sides send messages independently — chat, collaborative editing, multiplexed control channels. | When ordering between directions doesn't matter — server-streaming + a separate unary call is simpler. |
+
+## Defining streaming methods
+
+Use the `stream` keyword on the request, response, or both in your `.proto` file:
+
+```protobuf
+service Events {
+  // Unary
+  rpc GetEvent(GetEventRequest) returns (Event) {}
+
+  // Server-streaming — one request, many responses
+  rpc StreamEvents(StreamEventsRequest) returns (stream Event) {}
+
+  // Client-streaming — many requests, one response
+  rpc UploadSamples(stream Sample) returns (UploadSummary) {}
+
+  // Bidirectional — many requests, many responses, independent timing
+  rpc Chat(stream ChatMessage) returns (stream ChatMessage) {}
+}
+```
+
+Run `buf generate` (or `make proto`) the same way you would for unary methods.
+
+## Handler patterns
+
+### Server-streaming
+
+The handler receives the request and a stream it can `Send` on as many times as it wants:
+
+```go
+func (s *EventsService) StreamEvents(req *pb.StreamEventsRequest, stream pb.Events_StreamEventsServer) error {
+    ctx := stream.Context()
+    for ev := range s.subscribe(ctx, req.GetTopic()) {
+        if err := stream.Send(ev); err != nil {
+            // Client disconnected or context cancelled — stop producing.
+            return err
+        }
+    }
+    return nil
+}
+```
+
+Two things to notice:
+- **Always honour `stream.Context()`.** If the client disconnects or hits its deadline, the context is cancelled — your producer goroutine should exit.
+- **`Send` returning an error means the stream is dead.** Don't keep producing.
+
+### Client-streaming
+
+The handler reads from the stream until `io.EOF`, then sends a single response:
+
+```go
+import "io"
+
+func (s *EventsService) UploadSamples(stream pb.Events_UploadSamplesServer) error {
+    var count int64
+    for {
+        sample, err := stream.Recv()
+        if err == io.EOF {
+            return stream.SendAndClose(&pb.UploadSummary{Count: count})
+        }
+        if err != nil {
+            return err
+        }
+        count++
+        // process sample
+    }
+}
+```
+
+`io.EOF` is the **expected** end-of-stream signal — it is not an error. Any other error means the client died or context was cancelled.
+
+### Bidirectional
+
+The simplest pattern is to read in a goroutine and write from the main goroutine (or vice versa). Use the stream's context to coordinate cancellation:
+
+```go
+func (s *ChatService) Chat(stream pb.Chat_ChatServer) error {
+    ctx := stream.Context()
+
+    // Reader goroutine
+    incoming := make(chan *pb.ChatMessage)
+    errCh := make(chan error, 1)
+    go func() {
+        defer close(incoming)
+        for {
+            msg, err := stream.Recv()
+            if err != nil {
+                errCh <- err
+                return
+            }
+            select {
+            case incoming <- msg:
+            case <-ctx.Done():
+                return
+            }
+        }
+    }()
+
+    for {
+        select {
+        case <-ctx.Done():
+            return ctx.Err()
+        case err := <-errCh:
+            if err == io.EOF {
+                return nil
+            }
+            return err
+        case msg := <-incoming:
+            reply := s.handle(msg)
+            if err := stream.Send(reply); err != nil {
+                return err
+            }
+        }
+    }
+}
+```
+
+This shape generalizes to any independent-timing protocol. For half-duplex flows (every Recv followed by a Send), a simple `for { Recv; ... ; Send }` loop is fine — but you lose the ability to push unsolicited messages from the server.
+
+## Deadline propagation
+
+Stream contexts inherit the client's deadline the same way unary calls do. When the client sets a per-call deadline:
+
+```go
+ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+defer cancel()
+stream, err := client.StreamEvents(ctx, req)
+```
+
+…then `stream.Context()` on the server side fires `Done()` at the same instant, and the next `Send` or `Recv` returns the cancellation error. **Always check `stream.Context().Err()` (or rely on `Send`/`Recv` returning) inside long-running loops** — that is your only signal to stop producing.
+
+For long-lived streams (chat, change feeds), a single deadline rarely makes sense. Instead, set keepalive on the gRPC client/server (the cookiecutter sets sensible defaults) and let TCP failures surface as context cancellation.
+
+## Backpressure
+
+gRPC-Go does not expose explicit flow-control hooks — `Send` blocks once the HTTP/2 send window fills, and that **is** the backpressure signal. The patterns that stay healthy:
+
+- **Producer-loop pattern.** Generate one item per loop iteration, call `stream.Send`, check the error, and only then move on. If the consumer is slow, your loop slows naturally.
+- **Bounded buffer between source and stream.** If the data source can't be paced (e.g. it's a Kafka subscription), put a bounded channel between the source and the gRPC `Send` loop. When the channel fills, drop or block at the source — explicitly, not by accident.
+- **Don't fan-out into goroutines per message.** Each `stream.Send` must complete before the next one starts; goroutines all calling `Send` on the same stream race.
+
+If you need true high-throughput multiplexing on a single stream, consider chunking many logical messages into one large protobuf message instead of relying on per-message backpressure.
+
+## grpc-gateway HTTP support
+
+grpc-gateway translates streaming RPCs to HTTP, but the four shapes don't map cleanly to HTTP/1.1:
+
+| gRPC shape | HTTP behaviour through the gateway |
+|---|---|
+| Unary | Standard request/response. |
+| Server-streaming | Newline-delimited JSON (NDJSON) over a chunked HTTP response. Clients read line-by-line. |
+| Client-streaming | Limited — the gateway buffers and forwards as a unary gRPC stream. Don't rely on this for large or long-lived uploads. |
+| Bidirectional | Limited — no true concurrent interleaving over HTTP/1.1. Avoid for HTTP clients. |
+
+Practical things to know:
+
+- **Reverse proxies buffer streamed responses.** Nginx, Cloudflare, and similar will hold chunks until they have "enough." Set `X-Accel-Buffering: no` on the response (or the upstream config) to disable buffering when you actually need server-streaming over HTTP.
+- **Stream errors need a handler.** Use `runtime.WithStreamErrorHandler` when registering the gateway to control how mid-stream errors render in the HTTP response. The default trailers-only behaviour is awkward to consume from a JSON client.
+- **Native HTTP alternatives.** If your HTTP clients need true bidirectional or high-frequency push, consider a separate WebSocket or Server-Sent Events endpoint registered via [HTTP Gateway Extensions](/howto/gateway-extensions). Keep the gRPC stream as the canonical implementation and have the WebSocket handler delegate to it.
+
+See the [grpc-gateway streaming examples](https://github.com/grpc-ecosystem/grpc-gateway/tree/main/examples/internal/proto/examplepb) for the full HTTP semantics.
+
+## Related
+
+- [APIs how-to](/howto/APIs) — Defining gRPC and HTTP endpoints from proto.
+- [Interceptors](/howto/interceptors) — The stream interceptor chain and how to add your own.
+- [HTTP Gateway Extensions](/howto/gateway-extensions) — Custom marshalers and routes when the gateway alone isn't enough.
+- [Tracing](/howto/Tracing) — Trace IDs propagate through stream contexts the same way they do for unary.

--- a/tests/content.spec.ts
+++ b/tests/content.spec.ts
@@ -1,5 +1,14 @@
 import { test, expect } from "@playwright/test";
 
+// Newer how-to pages, listed once and reused by the SEO and TOC test sets so
+// adding a page only requires touching one list.
+const newHowtoPages = [
+  "/howto/streaming-rpcs/",
+  "/howto/database/",
+  "/howto/cache/",
+  "/howto/messaging/",
+];
+
 test.describe("Code Blocks", () => {
   test("home page renders code blocks", async ({ page }) => {
     await page.goto("/");
@@ -206,6 +215,57 @@ test.describe("Factual accuracy", () => {
     await expect(mainContent).toContainText("ADMIN_PORT");
     await expect(mainContent).toContainText("canary");
   });
+
+  test("concepts page defines the core gRPC and observability terms", async ({ page }) => {
+    await page.goto("/concepts/");
+    const mainContent = page.locator("main, .main-content").first();
+    await expect(mainContent.getByRole("heading", { name: "gRPC", exact: true })).toBeVisible();
+    await expect(mainContent.getByRole("heading", { name: "Interceptors" })).toBeVisible();
+    await expect(mainContent.getByRole("heading", { name: "vtprotobuf" })).toBeVisible();
+    await expect(mainContent.getByRole("heading", { name: "Trace ID" })).toBeVisible();
+    await expect(mainContent.getByRole("heading", { name: "Lifecycle hooks" })).toBeVisible();
+    await expect(mainContent.getByRole("heading", { name: "Healthcheck vs readycheck" })).toBeVisible();
+  });
+
+  test("streaming-rpcs covers all four shapes and gateway limits", async ({ page }) => {
+    await page.goto("/howto/streaming-rpcs/");
+    const mainContent = page.locator("main, .main-content").first();
+    await expect(mainContent).toContainText("Server-streaming");
+    await expect(mainContent).toContainText("Client-streaming");
+    await expect(mainContent).toContainText("Bidirectional");
+    await expect(mainContent).toContainText("Backpressure");
+    await expect(mainContent).toContainText("X-Accel-Buffering");
+  });
+
+  test("database howto documents the framework pattern with config", async ({ page }) => {
+    await page.goto("/howto/database/");
+    const mainContent = page.locator("main, .main-content").first();
+    await expect(mainContent).toContainText("PreStart");
+    await expect(mainContent).toContainText("CBStopper");
+    await expect(mainContent).toContainText("NewDatastoreSpan");
+    await expect(mainContent).toContainText("config.Get()");
+    await expect(mainContent).toContainText("DATABASE_URL");
+  });
+
+  test("cache howto documents the framework pattern with config", async ({ page }) => {
+    await page.goto("/howto/cache/");
+    const mainContent = page.locator("main, .main-content").first();
+    await expect(mainContent).toContainText("PreStart");
+    await expect(mainContent).toContainText("Cache-aside");
+    await expect(mainContent).toContainText("NewDatastoreSpan");
+    await expect(mainContent).toContainText("config.Get()");
+    await expect(mainContent).toContainText("REDIS_ADDR");
+  });
+
+  test("messaging howto documents Kafka and NATS via workers and config", async ({ page }) => {
+    await page.goto("/howto/messaging/");
+    const mainContent = page.locator("main, .main-content").first();
+    await expect(mainContent).toContainText("CBWorkerProvider");
+    await expect(mainContent).toContainText("Kafka");
+    await expect(mainContent).toContainText("NATS");
+    await expect(mainContent).toContainText("config.Get()");
+    await expect(mainContent).toContainText("at-least-once");
+  });
 });
 
 test.describe("SEO", () => {
@@ -226,6 +286,8 @@ test.describe("SEO", () => {
     "/howto/auth/",
     "/howto/local-dev/",
     "/howto/gateway-extensions/",
+    "/concepts/",
+    ...newHowtoPages,
   ];
 
   for (const pagePath of pagesWithDescriptions) {
@@ -256,6 +318,7 @@ test.describe("Table of Contents", () => {
     "/howto/auth/",
     "/howto/local-dev/",
     "/howto/gateway-extensions/",
+    ...newHowtoPages,
   ];
 
   for (const pagePath of howtoPages) {

--- a/tests/content.spec.ts
+++ b/tests/content.spec.ts
@@ -1,5 +1,17 @@
 import { test, expect } from "@playwright/test";
-import { newHowtoPages } from "./pages";
+import { allHowtoPages } from "./pages";
+
+const topLevelPages = [
+  "/",
+  "/getting-started/",
+  "/architecture/",
+  "/concepts/",
+  "/config-reference/",
+  "/howto/",
+  "/integrations/",
+  "/faq/",
+  "/packages/",
+];
 
 test.describe("Code Blocks", () => {
   test("home page renders code blocks", async ({ page }) => {
@@ -261,26 +273,7 @@ test.describe("Factual accuracy", () => {
 });
 
 test.describe("SEO", () => {
-  const pagesWithDescriptions = [
-    "/",
-    "/getting-started/",
-    "/architecture/",
-    "/config-reference/",
-    "/howto/",
-    "/integrations/",
-    "/faq/",
-    "/packages/",
-    "/howto/APIs/",
-    "/howto/workers/",
-    "/howto/readiness/",
-    "/howto/production/",
-    "/howto/interceptors/",
-    "/howto/auth/",
-    "/howto/local-dev/",
-    "/howto/gateway-extensions/",
-    "/concepts/",
-    ...newHowtoPages,
-  ];
+  const pagesWithDescriptions = [...topLevelPages, ...allHowtoPages];
 
   for (const pagePath of pagesWithDescriptions) {
     test(`${pagePath} has meta description`, async ({ page }) => {
@@ -297,23 +290,7 @@ test.describe("SEO", () => {
 });
 
 test.describe("Table of Contents", () => {
-  const howtoPages = [
-    "/howto/APIs/",
-    "/howto/gRPC/",
-    "/howto/Log/",
-    "/howto/errors/",
-    "/howto/Tracing/",
-    "/howto/interceptors/",
-    "/howto/workers/",
-    "/howto/readiness/",
-    "/howto/production/",
-    "/howto/auth/",
-    "/howto/local-dev/",
-    "/howto/gateway-extensions/",
-    ...newHowtoPages,
-  ];
-
-  for (const pagePath of howtoPages) {
+  for (const pagePath of allHowtoPages) {
     test(`${pagePath} has table of contents`, async ({ page }) => {
       await page.goto(pagePath);
       const toc = page.locator("#table-of-contents, .no_toc, #toc");

--- a/tests/content.spec.ts
+++ b/tests/content.spec.ts
@@ -1,13 +1,5 @@
 import { test, expect } from "@playwright/test";
-
-// Newer how-to pages, listed once and reused by the SEO and TOC test sets so
-// adding a page only requires touching one list.
-const newHowtoPages = [
-  "/howto/streaming-rpcs/",
-  "/howto/database/",
-  "/howto/cache/",
-  "/howto/messaging/",
-];
+import { newHowtoPages } from "./pages";
 
 test.describe("Code Blocks", () => {
   test("home page renders code blocks", async ({ page }) => {

--- a/tests/content.spec.ts
+++ b/tests/content.spec.ts
@@ -227,7 +227,7 @@ test.describe("Factual accuracy", () => {
     await expect(mainContent.getByRole("heading", { name: "Healthcheck vs readycheck" })).toBeVisible();
   });
 
-  test("streaming-rpcs covers all four shapes and gateway limits", async ({ page }) => {
+  test("streaming-rpcs covers the three streaming shapes and gateway limits", async ({ page }) => {
     await page.goto("/howto/streaming-rpcs/");
     const mainContent = page.locator("main, .main-content").first();
     await expect(mainContent).toContainText("Server-streaming");

--- a/tests/links.spec.ts
+++ b/tests/links.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from "@playwright/test";
-import { newHowtoPages } from "./pages";
+import { allHowtoPages } from "./pages";
 
 /**
  * Collect all unique internal links from a page.
@@ -24,18 +24,14 @@ async function getInternalLinks(
 test.describe("Internal Links", () => {
   const pagesToCrawl = [
     "/",
-    "/howto/",
-    "/howto/APIs/",
-    "/integrations/",
-    "/packages/",
-    "/howto/production/",
-    "/howto/workers/",
-    "/howto/readiness/",
-    "/howto/gateway-extensions/",
     "/architecture/",
-    "/config-reference/",
     "/concepts/",
-    ...newHowtoPages,
+    "/config-reference/",
+    "/howto/",
+    "/integrations/",
+    "/faq/",
+    "/packages/",
+    ...allHowtoPages,
   ];
 
   for (const pagePath of pagesToCrawl) {

--- a/tests/links.spec.ts
+++ b/tests/links.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from "@playwright/test";
+import { newHowtoPages } from "./pages";
 
 /**
  * Collect all unique internal links from a page.
@@ -33,6 +34,8 @@ test.describe("Internal Links", () => {
     "/howto/gateway-extensions/",
     "/architecture/",
     "/config-reference/",
+    "/concepts/",
+    ...newHowtoPages,
   ];
 
   for (const pagePath of pagesToCrawl) {

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -4,6 +4,7 @@ const topLevelPages = [
   { path: "/", title: "ColdBrew" },
   { path: "/getting-started/", title: "Getting Started" },
   { path: "/architecture/", title: "Architecture" },
+  { path: "/concepts/", title: "Concepts" },
   { path: "/howto/", title: "How To" },
   { path: "/integrations/", title: "Integrations" },
   { path: "/faq/", title: "Frequently Asked Questions" },
@@ -32,6 +33,10 @@ const howtoPages = [
   "/howto/readiness/",
   "/howto/local-dev/",
   "/howto/gateway-extensions/",
+  "/howto/streaming-rpcs/",
+  "/howto/database/",
+  "/howto/cache/",
+  "/howto/messaging/",
 ];
 
 test.describe("Page Loading", () => {

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { allHowtoPages } from "./pages";
 
 const topLevelPages = [
   { path: "/", title: "ColdBrew" },
@@ -12,33 +13,6 @@ const topLevelPages = [
   { path: "/config-reference/", title: "Configuration Reference" },
 ];
 
-const howtoPages = [
-  "/howto/APIs/",
-  "/howto/gRPC/",
-  "/howto/Log/",
-  "/howto/errors/",
-  "/howto/Tracing/",
-  "/howto/Metrics/",
-  "/howto/interceptors/",
-  "/howto/Debugging/",
-  "/howto/signals/",
-  "/howto/swagger/",
-  "/howto/data-builder/",
-  "/howto/vtproto/",
-  "/howto/production/",
-  "/howto/testing/",
-  "/howto/workers/",
-  "/howto/private-modules/",
-  "/howto/auth/",
-  "/howto/readiness/",
-  "/howto/local-dev/",
-  "/howto/gateway-extensions/",
-  "/howto/streaming-rpcs/",
-  "/howto/database/",
-  "/howto/cache/",
-  "/howto/messaging/",
-];
-
 test.describe("Page Loading", () => {
   for (const page of topLevelPages) {
     test(`top-level page loads: ${page.path}`, async ({ page: p }) => {
@@ -48,7 +22,7 @@ test.describe("Page Loading", () => {
     });
   }
 
-  for (const path of howtoPages) {
+  for (const path of allHowtoPages) {
     test(`howto page loads: ${path}`, async ({ page }) => {
       const response = await page.goto(path);
       expect(response?.status()).toBe(200);

--- a/tests/pages.ts
+++ b/tests/pages.ts
@@ -1,0 +1,8 @@
+// Newer how-to pages, declared once and shared across the test files so a
+// new how-to only needs to be added in one place.
+export const newHowtoPages = [
+  "/howto/streaming-rpcs/",
+  "/howto/database/",
+  "/howto/cache/",
+  "/howto/messaging/",
+];

--- a/tests/pages.ts
+++ b/tests/pages.ts
@@ -1,28 +1,28 @@
-// All how-to pages on the docs site, in sidebar order. Imported by every
-// test suite that walks the how-tos so adding a how-to is one edit.
+// All how-to pages on the docs site, in sidebar (nav_order) order. Imported
+// by every test suite that walks the how-tos so adding a how-to is one edit.
 export const allHowtoPages = [
-  "/howto/APIs/",
-  "/howto/gRPC/",
-  "/howto/Log/",
-  "/howto/errors/",
-  "/howto/Tracing/",
-  "/howto/Metrics/",
-  "/howto/interceptors/",
-  "/howto/Debugging/",
-  "/howto/signals/",
-  "/howto/swagger/",
-  "/howto/data-builder/",
-  "/howto/vtproto/",
-  "/howto/production/",
-  "/howto/testing/",
-  "/howto/workers/",
-  "/howto/private-modules/",
-  "/howto/auth/",
-  "/howto/readiness/",
-  "/howto/local-dev/",
-  "/howto/gateway-extensions/",
-  "/howto/streaming-rpcs/",
-  "/howto/database/",
-  "/howto/cache/",
-  "/howto/messaging/",
+  "/howto/APIs/",                // 1
+  "/howto/gRPC/",                // 2
+  "/howto/Log/",                 // 3
+  "/howto/errors/",              // 4
+  "/howto/Tracing/",             // 5
+  "/howto/Metrics/",             // 6
+  "/howto/interceptors/",        // 7
+  "/howto/Debugging/",           // 8
+  "/howto/signals/",             // 9
+  "/howto/swagger/",             // 10
+  "/howto/data-builder/",        // 11
+  "/howto/vtproto/",             // 12
+  "/howto/production/",          // 13
+  "/howto/testing/",             // 14
+  "/howto/workers/",             // 15
+  "/howto/private-modules/",     // 16
+  "/howto/readiness/",           // 17
+  "/howto/local-dev/",           // 18
+  "/howto/auth/",                // 19
+  "/howto/gateway-extensions/",  // 20
+  "/howto/streaming-rpcs/",      // 21
+  "/howto/database/",            // 22
+  "/howto/cache/",               // 23
+  "/howto/messaging/",           // 24
 ];

--- a/tests/pages.ts
+++ b/tests/pages.ts
@@ -1,6 +1,26 @@
-// Newer how-to pages, declared once and shared across the test files so a
-// new how-to only needs to be added in one place.
-export const newHowtoPages = [
+// All how-to pages on the docs site, in sidebar order. Imported by every
+// test suite that walks the how-tos so adding a how-to is one edit.
+export const allHowtoPages = [
+  "/howto/APIs/",
+  "/howto/gRPC/",
+  "/howto/Log/",
+  "/howto/errors/",
+  "/howto/Tracing/",
+  "/howto/Metrics/",
+  "/howto/interceptors/",
+  "/howto/Debugging/",
+  "/howto/signals/",
+  "/howto/swagger/",
+  "/howto/data-builder/",
+  "/howto/vtproto/",
+  "/howto/production/",
+  "/howto/testing/",
+  "/howto/workers/",
+  "/howto/private-modules/",
+  "/howto/auth/",
+  "/howto/readiness/",
+  "/howto/local-dev/",
+  "/howto/gateway-extensions/",
   "/howto/streaming-rpcs/",
   "/howto/database/",
   "/howto/cache/",


### PR DESCRIPTION
## Summary

Five new pages plus cross-links and matching test coverage:

- **`/concepts`** — top-level glossary. One paragraph per term (gRPC, interceptors, vtprotobuf, OTLP, trace ID, span, lifecycle hooks, healthcheck vs readycheck, …) with a link into the deeper how-to. Drops the "you must already know gRPC" prerequisite without duplicating canonical content.
- **`/howto/streaming-rpcs`** — server-streaming, client-streaming, and bidi handler patterns; deadline propagation; backpressure; the practical limits of grpc-gateway over HTTP. The FAQ entry shrinks to a one-line pointer at this page.
- **`/howto/database`**, **`/howto/cache`**, **`/howto/messaging`** — the framework patterns for long-lived dependencies. ColdBrew is database / cache / broker agnostic, so these pages document the lifecycle hooks (`PreStart` / `Stop`) and worker integration (`CBWorkerProvider`) and ground each pattern in one concrete library: pgx for Postgres, go-redis for Redis/Valkey, IBM/sarama for Kafka, and nats.go for NATS.

The Kafka example uses sarama's consumer-group API (`MarkMessage` only after handler success) so the at-least-once guarantee the surrounding prose claims is actually delivered. The NATS example uses `ChanQueueSubscribe` + `workers.ChannelWorker`, which keeps the consumer loop in the framework and leaves the handler as a pure `func(ctx, info, *nats.Msg) error` — broker-agnostic, unit-testable, and the channel is the seam.

## Configuration pattern

Every example loads user config through the cookiecutter's `config/` package — extend the `Config` struct with `envconfig` tags and access via `config.Get().FieldName`, matching the cookiecutter's own `config/config.go`. No raw `os.Getenv`.

## Cross-links

- `/howto/local-dev` now points at the database, cache, and messaging how-tos next to the matching profile tables.
- `/howto/signals` step 4 ("Stop workers") points at the messaging how-to for the consumer-drain pattern.

## Tests

- New content assertions cover the new pages: required headings on `/concepts/`, key sections on `/howto/streaming-rpcs/`, and `config.Get()`-based examples on the three data how-tos.
- A `newHowtoPages` constant in `tests/pages.ts` is shared by `content.spec.ts` (SEO + TOC) and `links.spec.ts` (broken-link crawl) so adding a how-to only touches one list.
- `/concepts/` added to `topLevelPages`, SEO, TOC, and broken-link crawl sets.

## Test plan
- [ ] \`bundle exec jekyll build\` succeeds with no broken-link warnings
- [ ] \`npx playwright test tests/content.spec.ts\` — new "Factual accuracy" assertions pass against a local Jekyll server
- [ ] \`npx playwright test tests/navigation.spec.ts\` — all five new pages return 200
- [ ] \`npx playwright test tests/links.spec.ts\` — internal-link crawl now also visits \`/concepts/\` and the four new how-tos
- [ ] Spot-check the rendered site: \`/concepts/\`, \`/howto/streaming-rpcs/\`, \`/howto/database/\`, \`/howto/cache/\`, \`/howto/messaging/\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Added Concepts glossary defining core ColdBrew terminology and features
- Added how-to guides for Streaming RPCs, Database integration, Cache integration (Redis/Valkey), and Messaging patterns (Kafka/NATS)
- Streamlined gRPC streaming FAQ entry with link to detailed how-to
- Enhanced local development documentation with lifecycle pattern references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->